### PR TITLE
🛑 Show time-entry info on stopping

### DIFF
--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -14,8 +14,12 @@ impl StopCommand {
             Some(running_time_entry) => {
                 let stop_time = Utc::now();
                 let stopped_time_entry = running_time_entry.as_stopped_time_entry(stop_time);
-                let _ = api_client.update_time_entry(stopped_time_entry).await?;
-                println!("{}", "Time entry stopped successfully".green());
+                let updated_time_entry = api_client.update_time_entry(stopped_time_entry).await?;
+                println!(
+                    "{}\n{}",
+                    "Time entry stopped successfully".green(),
+                    updated_time_entry
+                );
             }
         }
 


### PR DESCRIPTION
- Log time-entry when it's stopped, to match start behaviour

![image](https://user-images.githubusercontent.com/1716853/133460722-95ceedef-be33-4792-b36a-6457c7bb71e5.png)

Closes #32