### PR TITLE
✏️ Rename binary to toggl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,7 +1968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
-name = "toggl-cli"
+name = "toggl"
 version = "0.1.0"
 dependencies = [
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "toggl-cli"
+name = "toggl"
 version = "0.1.0"
 authors = ["William Barbosa <heytherewill@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Installing the binary.
 ```shell
 cargo install --path .
 ```
-> This places the release optimized binary at `~/.cargo/bin/toggl-cli`. Make sure to add `~/.cargo/bin` to your `$PATH` so that you can run the binary from any directory.
+> This places the release optimized binary at `~/.cargo/bin/toggl`. Make sure to add `~/.cargo/bin` to your `$PATH` so that you can run the binary from any directory.
 
-You can invoke the binary using the `toggl-cli` command  now. Alternativly you can also run the command directly using `cargo run`
+You can invoke the binary using the `toggl` command  now. Alternativly you can also run the command directly using `cargo run`
 
 ```shell
 cargo run [command]
@@ -30,7 +30,7 @@ cargo run list -n 3
 The first command you need to run is `auth` to set up your [Toggl API token](https://support.toggl.com/en/articles/3116844-where-is-my-api-token-located).
 
 ```shell
-cargo run auth [API_TOKEN] # or toggl-cli auth [API_TOKEN]
+cargo run auth [API_TOKEN] # or toggl auth [API_TOKEN]
 ```
 
 The API token is stored securely in your Operating System's keychain using the [keyring](https://crates.io/crates/keyring) crate.
@@ -40,12 +40,12 @@ The API token is stored securely in your Operating System's keychain using the [
 Run the `help` command to see a list of available commands.
 
 ```shell
-$ toggl-cli help
+$ toggl help
 toggl 0.1.0
 Toggl command line app.
 
 USAGE:
-    toggl-cli [SUBCOMMAND]
+    toggl [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
@@ -65,11 +65,11 @@ SUBCOMMANDS:
 You can also run the `help` command on a specific subcommand.
 
 ```shell
-$ toggl-cli help start
-toggl-cli-start 0.1.0
+$ toggl help start
+toggl-start 0.1.0
 
 USAGE:
-    toggl-cli start [FLAGS] [OPTIONS] --description <description>
+    toggl start [FLAGS] [OPTIONS] --description <description>
 
 FLAGS:
     -b, --billable


### PR DESCRIPTION
This renames the binary from `toggl-cli` to `toggl`, since it's obviously a cli app when it's being invoked from the command line