### PR TITLE
🏗 Reuse StopCommand code for other commands

### DIFF
--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -3,26 +3,48 @@ use crate::models;
 use api::ApiClient;
 use chrono::Utc;
 use colored::Colorize;
-use models::ResultWithDefaultError;
+use models::{ResultWithDefaultError, TimeEntry};
 
 pub struct StopCommand;
 
+pub enum StopCommandOrigin {
+    CommandLine,
+    StartCommand,
+    ContinueCommand,
+}
+
 impl StopCommand {
-    pub async fn execute(api_client: impl ApiClient) -> ResultWithDefaultError<()> {
+    pub async fn execute(
+        api_client: &impl ApiClient,
+        origin: StopCommandOrigin,
+    ) -> ResultWithDefaultError<Option<TimeEntry>> {
         match api_client.get_running_time_entry().await? {
-            None => println!("{}", "No time entry is running at the moment".yellow()),
+            None => {
+                match origin {
+                    StopCommandOrigin::CommandLine => {
+                        println!("{}", "No time entry is running at the moment".yellow())
+                    }
+                    StopCommandOrigin::StartCommand => (),
+                    StopCommandOrigin::ContinueCommand => (),
+                };
+
+                Ok(None)
+            }
             Some(running_time_entry) => {
                 let stop_time = Utc::now();
                 let stopped_time_entry = running_time_entry.as_stopped_time_entry(stop_time);
                 let updated_time_entry = api_client.update_time_entry(stopped_time_entry).await?;
-                println!(
-                    "{}\n{}",
-                    "Time entry stopped successfully".green(),
-                    updated_time_entry
-                );
+
+                let message = match origin {
+                    StopCommandOrigin::CommandLine => "Time entry stopped successfully".green(),
+                    StopCommandOrigin::StartCommand => "Running time entry stopped".yellow(),
+                    StopCommandOrigin::ContinueCommand => "Running time entry stopped".yellow(),
+                };
+
+                println!("{}\n{}", message, updated_time_entry);
+
+                Ok(Some(updated_time_entry))
             }
         }
-
-        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use commands::cont::ContinueCommand;
 use commands::list::ListCommand;
 use commands::running::RunningTimeEntryCommand;
 use commands::start::StartCommand;
-use commands::stop::StopCommand;
+use commands::stop::{StopCommand, StopCommandOrigin};
 use credentials::{Credentials, CredentialsStorage, KeyringStorage};
 use keyring::Keyring;
 use models::ResultWithDefaultError;
@@ -48,7 +48,9 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
     match command {
         None => RunningTimeEntryCommand::execute(get_api_client()?).await?,
         Some(subcommand) => match subcommand {
-            Stop => StopCommand::execute(get_api_client()?).await?,
+            Stop => {
+                StopCommand::execute(&get_api_client()?, StopCommandOrigin::CommandLine).await?;
+            }
             Continue { interactive, fzf } => {
                 let picker = if interactive {
                     Some(picker::get_picker(fzf))


### PR DESCRIPTION
This is a tiny refactor PR that makes the start and continue commands use the stop command to ensure that there's no running time entry. ATM we are handling time entry stop in three different places and in three different ways. This way things are more concise and DRY