### PR TITLE
🌌 Resolve tracking config templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
  "colored",
  "directories",
  "keyring",
+ "lazy_static",
  "mockall",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "directories",
  "keyring",
  "mockall",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ keyring = "2"
 
 # Config
 directories = "5.0.0"
+lazy_static = "1.4.0"
 regex = "1.7.3"
 toml = "0.7.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ keyring = "2"
 
 # Config
 directories = "5.0.0"
+regex = "1.7.3"
 toml = "0.7.3"
 
 # API

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -65,4 +65,6 @@ pub enum Command {
 pub enum ConfigSubCommand {
     #[structopt(about = "Initialize a configuration file.")]
     Init,
+    #[structopt(about = "Report matching configuration block for current directory.")]
+    Active,
 }

--- a/src/config/active.rs
+++ b/src/config/active.rs
@@ -1,0 +1,13 @@
+use crate::models::ResultWithDefaultError;
+
+pub struct ConfigActiveCommand;
+
+impl ConfigActiveCommand {
+    pub async fn execute() -> ResultWithDefaultError<()> {
+        let config_path = super::locate::locate_config_path()?;
+        let track_config = super::parser::get_config_from_file(config_path)?;
+        let current_dir = std::env::current_dir()?;
+        println!("{}", track_config.get_branch_config_for_dir(&current_dir));
+        Ok(())
+    }
+}

--- a/src/config/fixtures/base.toml
+++ b/src/config/fixtures/base.toml
@@ -1,11 +1,11 @@
 # Branch (required)
 # Regex to choose which branch(-es) this block applies to, some examples
-# ["will\/.*"] applies to branches like`will/release-workflows`
-# ["\d\/.*"] applies to branches starting with numbers `123/feat-some-issue`
+# ['will/.*'] applies to branches like`will/release-workflows`
+# ['^\d+/.*'] applies to branches starting with numbers `123/feat-some-issue`
 # [main] applies only to the branch called `main`
-# ["*"] is the reserved default that applies if no block of higher precedence is present.
-# ["*"] It also applies if current folder is not tracked under source control
-["*"]
+# ['*'] is the reserved default that applies if no block of higher precedence is present.
+# ['*'] It also applies if current folder is not tracked under source control
+['*']
 
 # Workspace (optional, default={{default}}
 # {{default}} in this context would resolve to the user's default workspace

--- a/src/config/fixtures/base.toml
+++ b/src/config/fixtures/base.toml
@@ -9,11 +9,11 @@
 
 # Workspace (optional, default={{default}}
 # {{default}} in this context would resolve to the user's default workspace
-workspace = "{{default}}"
+workspace = "default"
 
 # Description (optional, default=null)
 # Accepts any string template with our marcros in them
-description = "🔨 {{current_branch}}"
+description = "🔨 {{branch}}"
 
 # Project (optional, default=null)
 project = "{{base_dir}}"

--- a/src/config/fixtures/complex.toml
+++ b/src/config/fixtures/complex.toml
@@ -1,5 +1,5 @@
 ["*"]
-description = "🔨 {{current_branch}} / {{active_dir}}"
+description = "🔨 {{branch}} / {{current_dir}}"
 project = "{{parent_base_dir}}"
 billable = true
 
@@ -12,7 +12,7 @@ billable = false
 # Match all branches that start with a number and a slash
 # e.g. 1234/feature-branch
 ["^\\d+\\/.*"]
-description = "🔨 {{current_branch}}"
+description = "🔨 {{branch}}"
 project = "{{base_dir}}"
 task = """
   {{$if [[ "$PWD" == *"android"* ]]; then echo "Android"; else echo "iOS"; fi}}

--- a/src/config/fixtures/complex.toml
+++ b/src/config/fixtures/complex.toml
@@ -13,7 +13,7 @@ billable = false
 # e.g. 1234/feature-branch
 ['^\d+/.*']
 description = "🔨 {{branch}}"
-project = "{{base_dir}}"
+project = "{{git_root}}"
 task = """
   {{$if [[ "$PWD" == *"android"* ]]; then echo "Android"; else echo "iOS"; fi}}
 """

--- a/src/config/fixtures/complex.toml
+++ b/src/config/fixtures/complex.toml
@@ -11,7 +11,7 @@ billable = false
 
 # Match all branches that start with a number and a slash
 # e.g. 1234/feature-branch
-["^\\d+\\/.*"]
+['^\d+/.*']
 description = "🔨 {{branch}}"
 project = "{{base_dir}}"
 task = """

--- a/src/config/fixtures/default.toml
+++ b/src/config/fixtures/default.toml
@@ -14,7 +14,7 @@
 
 # Description (optional, default="")
 # Accepts any string template with our marcros in them
-description = "🔨 {{current_branch}}"
+description = "🔨 {{branch}}"
 
 # Project (optional, default=No project)
 # Accepts any string template with our marcros in them
@@ -36,7 +36,7 @@ billable = true
 # don't match any other block.
 
 # ["will\\/.*"]
-# description = "Review {{current_branch}}"
+# description = "Review {{branch}}"
 # project = "{{base_dir}}"
 # tags = ["review"]
 # billable = false

--- a/src/config/fixtures/default.toml
+++ b/src/config/fixtures/default.toml
@@ -18,7 +18,7 @@ description = "🔨 {{branch}}"
 
 # Project (optional, default=No project)
 # Accepts any string template with our marcros in them
-project = "{{base_dir}}"
+project = "{{git_root}}"
 
 # Task (optional, default=No task)
 # task = "Some task"

--- a/src/config/fixtures/default.toml
+++ b/src/config/fixtures/default.toml
@@ -1,11 +1,11 @@
 # Branch (required)
 # Regex to choose which branch(-es) this block applies to, some examples
-# ["will\\/.*"] applies to branches like`will/release-workflows`
-# ["^\\d+\\/.*"] applies to branches starting with numbers `123/feat-some-issue`
+# ['will/.*'] applies to branches like`will/release-workflows`
+# ['^\d+/.*'] applies to branches starting with numbers `123/feat-some-issue`
 # [main] applies only to the branch called `main`
-# ["*"] is the reserved default that applies if no block of higher precedence is present.
-# ["*"] It also applies if current folder is not tracked under source control
-["*"]
+# ['*'] is the reserved default that applies if no block of higher precedence is present.
+# ['*'] It also applies if current folder is not tracked under source control
+['*']
 
 # Workspace (optional, default=null)
 # in this context would resolve to the user's default workspace
@@ -35,7 +35,7 @@ billable = true
 # The exception is the default block, which is applied to all branches that
 # don't match any other block.
 
-# ["will\\/.*"]
+# ['will/.*']
 # description = "Review {{branch}}"
 # project = "{{base_dir}}"
 # tags = ["review"]

--- a/src/config/locate.rs
+++ b/src/config/locate.rs
@@ -1,8 +1,13 @@
 use std::path::{Path, PathBuf};
 
 use base64::{engine::general_purpose, Engine as _};
+use lazy_static::lazy_static;
 
 use crate::error::ConfigError;
+
+lazy_static! {
+    pub static ref TRACKED_PATH: Option<PathBuf> = locate_tracked_path().ok();
+}
 
 pub fn locate_config_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let config_root = get_config_root();
@@ -19,9 +24,7 @@ pub fn locate_config_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(config_filename)
 }
 
-/// TODO: Cache config_path to avoid calling locate_tracked_path() multiple times
-/// It's guaranteed to be the same for the duration of the program
-pub fn locate_tracked_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn locate_tracked_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let config_root = get_config_root();
 
     let mut config_path = std::env::current_dir()?;

--- a/src/config/locate.rs
+++ b/src/config/locate.rs
@@ -6,9 +6,10 @@ use crate::error::ConfigError;
 
 pub fn locate_config_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let config_root = get_config_root();
-    let mut config_path = std::env::current_dir()?;
 
+    let mut config_path = std::env::current_dir()?;
     let mut config_filename = get_encoded_config_path(&config_root, &config_path);
+
     while !config_filename.exists() {
         if !config_path.pop() {
             return Err(Box::new(ConfigError::FileNotFound));
@@ -16,6 +17,23 @@ pub fn locate_config_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
         config_filename = get_encoded_config_path(&config_root, &config_path);
     }
     Ok(config_filename)
+}
+
+/// TODO: Cache config_path to avoid calling locate_tracked_path() multiple times
+/// It's guaranteed to be the same for the duration of the program
+pub fn locate_tracked_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let config_root = get_config_root();
+
+    let mut config_path = std::env::current_dir()?;
+    let mut config_filename = get_encoded_config_path(&config_root, &config_path);
+
+    while !config_filename.exists() {
+        if !config_path.pop() {
+            return Err("No config file found".into());
+        }
+        config_filename = get_encoded_config_path(&config_root, &config_path);
+    }
+    Ok(config_path)
 }
 
 pub fn get_config_path_for_current_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {

--- a/src/config/manage.rs
+++ b/src/config/manage.rs
@@ -32,7 +32,10 @@ impl ConfigManageCommand {
                 println!("{}", config);
                 Ok(())
             }
-            Err(_) => Err(Box::new(ConfigError::Parse)),
+            Err(e) => {
+                println!("In config parse {}", e);
+                Err(Box::new(ConfigError::Parse))
+            }
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub mod active;
 pub mod init;
 pub mod locate;
 pub mod manage;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -5,6 +5,8 @@ use colored::Colorize;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
+use crate::utilities;
+
 /// BranchConfig optionally determines workspace, description, project, task,
 /// tags, and billable status of a time entry.
 /// The fields are optional, and if not specified, the default values will be
@@ -419,4 +421,22 @@ fn process_config_value(input: String) -> String {
     }
 
     result
+}
+
+impl TrackConfig {
+    fn get_branch_config(&self, branch: Option<&str>) -> &BranchConfig {
+        match branch {
+            Some(branch) => self
+                .branches
+                .iter()
+                .find(|(b, _)| b == branch)
+                .map(|(_, c)| c)
+                .unwrap_or(&self.default),
+            None => &self.default,
+        }
+    }
+    pub fn get_branch_config_for_dir(&self, dir: &PathBuf) -> &BranchConfig {
+        let branch = utilities::get_git_branch_for_dir(dir);
+        self.get_branch_config(branch.as_deref())
+    }
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -29,7 +29,7 @@ use crate::utilities;
 ///
 /// Given the following configuration:
 /// ```toml
-/// [default]
+/// ['my-.+']
 /// workspace = "Default"
 /// description = "Working on {{branch}} for {{base_dir}}"
 /// project = "Default"
@@ -439,7 +439,10 @@ impl TrackConfig {
             Some(branch) => self
                 .configs
                 .iter()
-                .find(|(b, _)| b == branch)
+                .find(|(b, _)| {
+                    let re = regex::Regex::new(b).expect("Invalid branch regex");
+                    re.is_match(branch)
+                })
                 .map(|(_, c)| c)
                 .unwrap_or(&self.default),
             None => &self.default,

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,16 +1,75 @@
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::os::unix::prelude::OsStrExt;
+use std::path::PathBuf;
+use std::{env, fmt};
 
 use colored::Colorize;
+use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+/// BranchConfig optionally determines workspace, description, project, task,
+/// tags, and billable status of a time entry.
+/// The fields are optional, and if not specified, the default values will be
+/// used. The string fields support templating, which will be replaced with live
+/// values on deserialization.
+///
+/// The templating syntax is `{{<field>}}`. The following fields are supported:
+/// - `branch` -- the name of the current branch
+/// - `base_dir` -- the base directory of the repository
+/// - `parent_base_dir` -- the base directory of the parent repository
+/// - `current_dir` -- the current working directory
+/// - `parent_dir` -- the parent directory of the current working directory
+/// - `$<shell_statement>` -- the output of the shell statement
+///
+/// The variables can be combined with other strings,
+/// e.g. `{{parent_base_dir}}/{{base_dir}}`.
+///
+/// The variables can also be used in the middle of a string,
+/// e.g. `Working on {{branch}} for {{base_dir}}`.
+///
+/// Given the following configuration:
+/// ```toml
+/// [default]
+/// workspace = "Default"
+/// description = "Working on {{branch}} for {{base_dir}}"
+/// project = "Default"
+/// task = "Development"
+/// tags = ["{{branch}}", "{{$ date +\"%Y\"}}"]
+/// billable = true
+/// ```
+///
+/// and the following shell state:
+/// ```bash
+/// $ git rev-parse --show-toplevel
+/// /Users/username/Projects/project
+/// $ pwd
+/// /Users/username/Projects/project/foo
+/// $ git rev-parse --abbrev-ref HEAD
+/// my-feature
+/// $ date +'%Y'
+/// 2023
+/// ```
+///
+/// the following time entry will be created:
+/// ```json
+/// {
+///  "workspace": "Default",
+///  "description": "Working on my-feature for project",
+///  "project": "Default",
+///  "task": "Development",
+///  "tags": ["my-feature", "2023"],
+///  "billable": true
+/// }
+/// ```
+#[derive(Debug, Serialize, Clone, Default)]
 pub struct BranchConfig {
     pub workspace: Option<String>,
     pub description: Option<String>,
     pub project: Option<String>,
     pub task: Option<String>,
     pub tags: Option<Vec<String>>,
-    pub billable: Option<bool>,
+    pub billable: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -19,28 +78,169 @@ pub struct TrackConfig {
     pub branches: HashMap<String, BranchConfig>,
 }
 
+impl<'de> Deserialize<'de> for BranchConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BranchConfigVisitor;
+
+        impl<'de> Visitor<'de> for BranchConfigVisitor {
+            type Value = BranchConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct BranchConfig")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let workspace = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let description = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let project = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                let task = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                let tags = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                let billable = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(5, &self))?;
+                Ok(BranchConfig {
+                    workspace,
+                    description,
+                    project,
+                    task,
+                    tags,
+                    billable,
+                })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut workspace: Option<String> = None;
+                let mut description: Option<String> = None;
+                let mut project: Option<String> = None;
+                let mut task: Option<String> = None;
+                let mut tags: Option<Vec<String>> = None;
+                let mut billable: Option<bool> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "workspace" => {
+                            if workspace.is_some() {
+                                return Err(de::Error::duplicate_field("workspace"));
+                            }
+                            workspace = Some(map.next_value().map(process_config_value)?);
+                        }
+                        "description" => {
+                            if description.is_some() {
+                                return Err(de::Error::duplicate_field("description"));
+                            }
+                            description = Some(map.next_value().map(process_config_value)?);
+                        }
+                        "project" => {
+                            if project.is_some() {
+                                return Err(de::Error::duplicate_field("project"));
+                            }
+                            project = Some(map.next_value().map(process_config_value)?);
+                        }
+                        "task" => {
+                            if task.is_some() {
+                                return Err(de::Error::duplicate_field("task"));
+                            }
+                            task = Some(map.next_value().map(process_config_value)?);
+                        }
+                        "tags" => {
+                            if tags.is_some() {
+                                return Err(de::Error::duplicate_field("tags"));
+                            }
+                            tags = Some(map.next_value()?).map(|tags: Vec<String>| {
+                                tags.into_iter().map(process_config_value).collect()
+                            });
+                        }
+                        "billable" => {
+                            if billable.is_some() {
+                                return Err(de::Error::duplicate_field("billable"));
+                            }
+                            billable = Some(map.next_value()?);
+                        }
+                        _ => {
+                            return Err(de::Error::unknown_field(
+                                &key,
+                                &[
+                                    "workspace",
+                                    "description",
+                                    "project",
+                                    "task",
+                                    "tags",
+                                    "billable",
+                                ],
+                            ));
+                        }
+                    }
+                }
+                Ok(BranchConfig {
+                    workspace,
+                    description,
+                    project,
+                    task,
+                    tags,
+                    billable: billable.unwrap_or(false),
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &[
+            "workspace",
+            "description",
+            "project",
+            "task",
+            "tags",
+            "billable",
+        ];
+
+        deserializer.deserialize_struct("BranchConfig", FIELDS, BranchConfigVisitor)
+    }
+}
+
 impl std::fmt::Display for BranchConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let summary = format!(
-            "{}: {}\n{}: {}\n{}: {}\n{}: {}\n{}: [{}]\n{}: {}\n",
+            "{}: {}\n{}: {}\n{}: {}\n{}: {}\n{}: {}\n{}: {}\n",
             "workspace".green(),
-            self.workspace.as_ref().unwrap_or(&"Default".to_string()),
+            self.workspace
+                .as_ref()
+                .unwrap_or(&"default".purple().to_string()),
             "description".green(),
-            self.description.as_ref().unwrap_or(&"None".to_string()),
+            self.description
+                .as_ref()
+                .unwrap_or(&"none".yellow().to_string()),
             "project".green(),
-            self.project.as_ref().unwrap_or(&"None".to_string()),
+            self.project
+                .as_ref()
+                .unwrap_or(&"none".yellow().to_string()),
             "task".green(),
-            self.task.as_ref().unwrap_or(&"None".to_string()).trim(),
+            self.task
+                .as_ref()
+                .unwrap_or(&"none".yellow().to_string())
+                .trim(),
             "tags".green(),
             self.tags
                 .as_ref()
-                .map(|tags| tags.join(", "))
-                .unwrap_or("None".to_string()),
+                .map(|tags| format!("[{}]", tags.join(", ")))
+                .unwrap_or("[]".yellow().to_string()),
             "billable".green(),
-            self.billable
-                .as_ref()
-                .map(|billable| billable.to_string())
-                .unwrap_or("None".to_string()),
+            self.billable,
         );
         write!(f, "{}", summary)
     }
@@ -62,4 +262,152 @@ impl std::fmt::Display for TrackConfig {
                 .join("\n")
         )
     }
+}
+
+enum Macro {
+    Branch,
+    BaseDir,
+    ParentBaseDir,
+    CurrentDir,
+    ParentDir,
+    Shell(String),
+}
+
+fn resolve_token_to_macro(token: &str) -> Option<Macro> {
+    match token {
+        "branch" => Some(Macro::Branch),
+        "base_dir" => Some(Macro::BaseDir),
+        "parent_base_dir" => Some(Macro::ParentBaseDir),
+        "current_dir" => Some(Macro::CurrentDir),
+        "parent_dir" => Some(Macro::ParentDir),
+        _ => {
+            if token.starts_with('$') {
+                let command = token.trim_start_matches('$').trim();
+                Some(Macro::Shell(command.to_string()))
+            } else {
+                println!("{} {}", "Invalid macro".red(), token.red().bold());
+                None
+            }
+        }
+    }
+}
+
+fn resolve_macro(instruction: Macro) -> Result<String, Box<dyn std::error::Error>> {
+    match instruction {
+        Macro::Branch => {
+            let output = std::process::Command::new("git")
+                .arg("rev-parse")
+                .arg("--abbrev-ref")
+                .arg("HEAD")
+                .output()?;
+            Ok(String::from_utf8(output.stdout)?.trim().to_string())
+        }
+        Macro::BaseDir => {
+            let base_dir = std::process::Command::new("git")
+                .arg("rev-parse")
+                .arg("--show-toplevel")
+                .output()
+                .map(|o| PathBuf::from(OsStr::from_bytes(&o.stdout)))?;
+            Ok(base_dir
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+                .trim()
+                .to_string())
+        }
+        Macro::ParentBaseDir => {
+            let base_dir = std::process::Command::new("git")
+                .arg("rev-parse")
+                .arg("--show-toplevel")
+                .output()
+                .map(|o| PathBuf::from(OsStr::from_bytes(&o.stdout)))?;
+            let parent_dir = base_dir
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            Ok(parent_dir)
+        }
+        Macro::CurrentDir => {
+            let output = env::current_dir()?;
+            Ok(output.file_name().unwrap().to_str().unwrap().to_string())
+        }
+        Macro::ParentDir => {
+            let current_dir = env::current_dir()?;
+            let parent_dir_path = current_dir.parent().unwrap().to_path_buf();
+            Ok(parent_dir_path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string())
+        }
+        Macro::Shell(command) => {
+            let output = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&command)
+                .output();
+            match output {
+                Ok(output) => {
+                    if !output.status.success() {
+                        println!(
+                            "{}: {}\n{}: {}",
+                            "Error resolving shell macro".red(),
+                            String::from_utf8(output.stderr)?.red().bold(),
+                            "Command".yellow(),
+                            command.yellow().bold()
+                        );
+                        return Ok(command);
+                    }
+                    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+                }
+                Err(e) => {
+                    println!(
+                        "{}: {}\n{}: {}",
+                        "Error resolving shell macro".red(),
+                        e.to_string().red().bold(),
+                        "Command".yellow(),
+                        command.yellow().bold()
+                    );
+                    return Ok(command);
+                }
+            }
+        }
+    }
+}
+
+fn resolve_token(token: &str) -> Result<String, Box<dyn std::error::Error>> {
+    match resolve_token_to_macro(token) {
+        Some(macro_) => resolve_macro(macro_),
+        None => Ok(token.to_string()),
+    }
+}
+
+fn process_config_value(input: String) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '{' && chars.peek() == Some(&'{') {
+            chars.next();
+            let mut token = String::new();
+            while let Some(c) = chars.next() {
+                if c == '}' && chars.peek() == Some(&'}') {
+                    chars.next();
+                    break;
+                }
+                token.push(c);
+            }
+            result.push_str(&resolve_token(&token).unwrap());
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -428,10 +428,7 @@ fn resolve_macro(
             }
         }
         Macro::Shell(command) => {
-            let output = std::process::Command::new("sh")
-                .arg("-c")
-                .arg(&command)
-                .output();
+            let output = utilities::get_shell_cmd(&command).output();
             match output {
                 Ok(output) => {
                     if !output.status.success() {

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -74,7 +74,7 @@ pub struct BranchConfig {
 #[derive(Debug, Serialize, Clone)]
 pub struct TrackConfig {
     pub default: BranchConfig,
-    pub branches: Vec<(String, BranchConfig)>,
+    pub configs: Vec<(String, BranchConfig)>,
 }
 
 impl<'de> Deserialize<'de> for BranchConfig {
@@ -232,7 +232,7 @@ impl std::fmt::Display for TrackConfig {
             f,
             "{}\n{}",
             summary,
-            self.branches
+            self.configs
                 .iter()
                 .map(|(branch, config)| {
                     format!("{}\n{}", format!("[{}]", branch).blue().bold(), config)
@@ -262,7 +262,7 @@ impl<'de> Deserialize<'de> for TrackConfig {
                 V: MapAccess<'de>,
             {
                 let mut default: Option<BranchConfig> = None;
-                let mut branches: Vec<(String, BranchConfig)> = Vec::new();
+                let mut configs: Vec<(String, BranchConfig)> = Vec::new();
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
                         "*" => {
@@ -272,18 +272,18 @@ impl<'de> Deserialize<'de> for TrackConfig {
                             default = Some(map.next_value()?);
                         }
                         _ => {
-                            if branches.iter().any(|(branch, _)| branch == &key) {
+                            if configs.iter().any(|(branch, _)| branch == &key) {
                                 // TODO: Report duplicate key error can't seem to figure out a way to
                                 // return the repeated branch here
                                 return Err(de::Error::duplicate_field("branch"));
                             }
-                            branches.push((key, map.next_value()?));
+                            configs.push((key, map.next_value()?));
                         }
                     }
                 }
                 Ok(TrackConfig {
                     default: default.unwrap_or(BranchConfig::default()),
-                    branches,
+                    configs,
                 })
             }
         }
@@ -437,7 +437,7 @@ impl TrackConfig {
     fn get_branch_config(&self, branch: Option<&str>) -> &BranchConfig {
         match branch {
             Some(branch) => self
-                .branches
+                .configs
                 .iter()
                 .find(|(b, _)| b == branch)
                 .map(|(_, c)| c)

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 use std::ffi::OsStr;
 use std::os::unix::prelude::OsStrExt;
 use std::path::PathBuf;
@@ -75,7 +75,7 @@ pub struct BranchConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TrackConfig {
     pub default: BranchConfig,
-    pub branches: HashMap<String, BranchConfig>,
+    pub branches: Vec<(String, BranchConfig)>,
 }
 
 impl<'de> Deserialize<'de> for BranchConfig {

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::{env, fmt};
 
 use colored::Colorize;
-use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
 /// BranchConfig optionally determines workspace, description, project, task,
@@ -90,38 +90,6 @@ impl<'de> Deserialize<'de> for BranchConfig {
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct BranchConfig")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let workspace = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let description = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                let project = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
-                let task = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(3, &self))?;
-                let tags = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(4, &self))?;
-                let billable = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(5, &self))?;
-                Ok(BranchConfig {
-                    workspace,
-                    description,
-                    project,
-                    task,
-                    tags,
-                    billable,
-                })
             }
 
             fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
@@ -374,7 +342,7 @@ fn resolve_macro(instruction: Macro) -> Result<String, Box<dyn std::error::Error
                         "Command".yellow(),
                         command.yellow().bold()
                     );
-                    return Ok(command);
+                    Ok(command)
                 }
             }
         }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,23 +1,13 @@
-use std::{collections::HashMap, path::Path};
+use std::path::Path;
 use toml;
 
-use super::model::{BranchConfig, TrackConfig};
-
-const DEFAULT_BRANCH: &str = "*";
+use super::model::TrackConfig;
 
 pub fn get_config_from_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<TrackConfig, Box<dyn std::error::Error>> {
     let contents = std::fs::read_to_string(path)?;
-    let mut branches: HashMap<String, BranchConfig> = toml::from_str(&contents)?;
+    let config: TrackConfig = toml::from_str(&contents)?;
 
-    let default = branches.get(DEFAULT_BRANCH).cloned().unwrap_or_default();
-
-    // Delete the default config from the branches config
-    branches.remove(DEFAULT_BRANCH);
-
-    Ok(TrackConfig {
-        default,
-        branches: branches.into_iter().collect(),
-    })
+    Ok(config)
 }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -11,13 +11,13 @@ pub fn get_config_from_file<P: AsRef<Path>>(
     let contents = std::fs::read_to_string(path)?;
     let mut branches: HashMap<String, BranchConfig> = toml::from_str(&contents)?;
 
-    let default_config = branches.get(DEFAULT_BRANCH).cloned().unwrap_or_default();
+    let default = branches.get(DEFAULT_BRANCH).cloned().unwrap_or_default();
 
     // Delete the default config from the branches config
     branches.remove(DEFAULT_BRANCH);
 
     Ok(TrackConfig {
-        default: default_config,
-        branches,
+        default,
+        branches: branches.into_iter().collect(),
     })
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,3 +11,5 @@ pub const FZF_NOT_INSTALLED_ERROR: &str = "fzf could not be found. Is it install
 pub const OPERATION_CANCELLED: &str = "Operation cancelled";
 pub const CONFIG_FILE_NOT_FOUND_ERROR: &str = "No config file found";
 pub const CONFIG_PARSE_ERROR: &str = "Failed to parse config file";
+pub const CONFIG_UNRECOGNIZED_MACRO_ERROR: &str = "Unrecognized macro in config file";
+pub const CONFIG_SHELL_MACRO_RESOLUTION_ERROR: &str = "Failed to resolve shell macro";

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,8 @@ impl Error for PickerError {}
 pub enum ConfigError {
     Parse,
     FileNotFound,
+    UnrecognizedMarco(String),
+    ShellResolution(String, String),
 }
 
 impl Display for ConfigError {
@@ -90,6 +92,22 @@ impl Display for ConfigError {
                     "{}\nRun {} to create one",
                     constants::CONFIG_FILE_NOT_FOUND_ERROR.red().bold(),
                     "toggl config init".blue().bold(),
+                )
+            }
+            ConfigError::UnrecognizedMarco(marco) => {
+                format!(
+                    "{}: {}",
+                    constants::CONFIG_UNRECOGNIZED_MACRO_ERROR.red().bold(),
+                    marco.red().bold(),
+                )
+            }
+            ConfigError::ShellResolution(command, output_or_error) => {
+                format!(
+                    "{}: {}\n{}: {}",
+                    constants::CONFIG_SHELL_MACRO_RESOLUTION_ERROR.red(),
+                    output_or_error.red().bold(),
+                    "Command".yellow(),
+                    command.yellow().bold(),
                 )
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,9 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
                     ConfigSubCommand::Init => {
                         config::init::ConfigInitCommand::execute(edit).await?;
                     }
+                    ConfigSubCommand::Active => {
+                        config::active::ConfigActiveCommand::execute().await?;
+                    }
                 },
                 None => config::manage::ConfigManageCommand::execute(delete, edit, path).await?,
             },

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use colored::Colorize;
@@ -46,6 +46,20 @@ where
         .expect("Failed to spawn editor");
     child.wait().expect("Failed to wait for editor");
     Ok(())
+}
+
+pub fn get_git_branch_for_dir(dir: &PathBuf) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("branch")
+        .arg("--show-current")
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8(output.stdout).ok()?;
+    Some(branch.trim().to_string())
 }
 
 fn print_without_buffer(text: &str) {

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -62,6 +62,22 @@ pub fn get_git_branch_for_dir(dir: &PathBuf) -> Option<String> {
     Some(branch.trim().to_string())
 }
 
+#[cfg(unix)]
+pub fn get_shell_cmd(command: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new("sh");
+    cmd.arg("-c");
+    cmd.arg(command);
+    cmd
+}
+
+#[cfg(windows)]
+pub fn get_shell_cmd(command: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new("cmd");
+    cmd.arg("/C");
+    cmd.arg(command);
+    cmd
+}
+
 fn print_without_buffer(text: &str) {
     print!("{}", text);
     io::stdout().flush().unwrap();


### PR DESCRIPTION
## :star2: What does this PR do?

- 🧠 Add custom deserialization for BranchConfig
- 🕴️ Store branch config as array
- 🌌 Add custom parsing for TrackConfig
- 🏋️‍♂️ Add `toggl config active`

## :bug: Recommendations for testing

- See config parsing demo.
  [![asciicast](https://asciinema.org/a/qQXexPPkAKHXULne9JM1t8on4.svg)](https://asciinema.org/a/qQXexPPkAKHXULne9JM1t8on4)
- Another demo showing the config matching via the `toggl config active` command
  [![asciicast](https://asciinema.org/a/r6fBXDNbA0DLEcTMwfaTW8Oai.svg)](https://asciinema.org/a/r6fBXDNbA0DLEcTMwfaTW8Oai)
- Try running `toggl config` for various macros and shell commands.
- Sample complex configuration with a bunch of shell expansions

```toml
['*']
description = "🔨 {{branch}} / {{current_dir}}"
project = "{{parent_base_dir}}"
billable = true

['alt']
description = "chore(release)"
project = "{{base_dir}}"
tags = ["release", "{{parent_dir}}"]
billable = false

# Match all branches that start with a number and a slash
# e.g. 1234/feature-branch
['^\d+/.*']
description = "🔨 {{branch}}"
project = "{{parent_dir}}/{{base_dir}}"
# Set task to android if the current directory contains "android"
# otherwise set it to iOS
task = """
  {{$if [[ "$PWD" == *"android"* ]]; then echo "Android"; else echo "iOS"; fi}}
"""
# Set tags to the current year
tags = ["code", "{{$ date +\"%Y\" }}"]
billable = true
```

### New commands introduced

```console
# Get active tracking configuration for current directory and branch
$ toggl config active
```

## :memo: Links to relevant issues/docs

See #45 which defines the marcro expansion mechanism.

## :speech_balloon: Summarise how you feel about this PR with a gif/image

![negroni-sbagliato](https://user-images.githubusercontent.com/1716853/231507501-29677828-3c6d-4aea-8425-987490aecb0e.gif)
