### PR TITLE
🧠 Interactive time entry start

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -174,6 +174,7 @@ impl ApiClient for V9ApiClient {
                         at: p.at,
                         created_at: p.created_at,
                         color: p.color.clone(),
+                        billable: p.billable,
                     },
                 )
             })
@@ -187,6 +188,7 @@ impl ApiClient for V9ApiClient {
                     Task {
                         id: t.id,
                         name: t.name.clone(),
+                        project: projects.get(&t.project_id).unwrap().clone(),
                         workspace_id: t.workspace_id,
                     },
                 )

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -30,6 +30,7 @@ pub struct NetworkProject {
     pub created_at: DateTime<Utc>,
     pub server_deleted_at: Option<DateTime<Utc>>,
     pub color: String,
+    pub billable: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -44,6 +45,7 @@ pub struct NetworkTask {
     pub id: i64,
     pub name: String,
     pub workspace_id: i64,
+    pub project_id: i64,
 }
 
 impl From<TimeEntry> for NetworkTimeEntry {

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -42,7 +42,7 @@ pub enum Command {
         )]
         project: Option<String>,
         #[structopt(short, long)]
-        billable: Option<bool>,
+        billable: bool,
     },
     Continue {
         #[structopt(short, long)]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -31,14 +31,18 @@ pub enum Command {
         about = "Start a new time entry. Call with no arguments to start in interactive mode."
     )]
     Start {
-        #[structopt(
-            help = "Description of the time entry. If not specified, the user will be prompted to enter it."
-        )]
-        description: Option<String>,
         #[structopt(short, long)]
+        interactive: bool,
+        #[structopt(help = "Description of the time entry.")]
+        description: Option<String>,
+        #[structopt(
+            short,
+            long,
+            help = "Exact name of the project you want the time entry to be associated with."
+        )]
         project: Option<String>,
         #[structopt(short, long)]
-        billable: bool,
+        billable: Option<bool>,
     },
     Continue {
         #[structopt(short, long)]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -8,6 +8,9 @@ pub struct CommandLineArguments {
 
     #[structopt(long, help = "Use custom proxy")]
     pub proxy: Option<String>,
+
+    #[structopt(long, help = "Use fzf instead of the default picker")]
+    pub fzf: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -40,9 +43,6 @@ pub enum Command {
     Continue {
         #[structopt(short, long)]
         interactive: bool,
-
-        #[structopt(long)]
-        fzf: bool,
     },
     #[structopt(about = "Manage auto-tracking configuration")]
     Config {

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -36,7 +36,7 @@ impl ContinueCommand {
                 let picked_time_entry = entities
                     .time_entries
                     .iter()
-                    .find(|te| te.id == picked_id)
+                    .find(|te| te.id == picked_id.id)
                     .unwrap();
                 Some(picked_time_entry.clone())
             }

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -32,11 +32,11 @@ impl ContinueCommand {
                     .iter()
                     .map(|te| PickableItem::from_time_entry(te.clone()))
                     .collect();
-                let picked_id = time_entry_picker.pick(pickable_items)?;
+                let picked_key = time_entry_picker.pick(pickable_items)?;
                 let picked_time_entry = entities
                     .time_entries
                     .iter()
-                    .find(|te| te.id == picked_id.id)
+                    .find(|te| te.id == picked_key.id)
                     .unwrap();
                 Some(picked_time_entry.clone())
             }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,6 +1,11 @@
 use crate::api;
 use crate::commands;
 use crate::models;
+use crate::models::Entities;
+use crate::models::Project;
+use crate::picker::ItemPicker;
+use crate::picker::PickableItem;
+use crate::picker::PickableItemKind;
 use crate::utilities;
 use api::client::ApiClient;
 use colored::Colorize;
@@ -10,23 +15,76 @@ use models::TimeEntry;
 
 pub struct StartCommand;
 
-fn interactively_create_time_entry(workspace_id: i64) -> TimeEntry {
-    let yes_or_no = [
+fn interactively_create_time_entry(
+    workspace_id: i64,
+    entities: Entities,
+    picker: Box<dyn ItemPicker>,
+    description: Option<String>,
+    project: Option<Project>,
+    billable: Option<bool>,
+) -> TimeEntry {
+    let yes_or_default_no = [
         "y".to_string(),
         "n".to_string(),
         "N".to_string(),
         "".to_string(),
     ];
-    let description = utilities::read_from_stdin("Description: ");
-    let billable = utilities::read_from_stdin_with_constraints(
-        "Is your time entry billable? (y/N): ",
-        &yes_or_no,
-    ) == "y";
+
+    let description = description.unwrap_or(utilities::read_from_stdin("Description: "));
+
+    let (project, task) = match project {
+        Some(_) => (project, None),
+        None => {
+            if entities.projects.is_empty() {
+                (None, None)
+            } else {
+                let mut pickable_items: Vec<PickableItem> = entities
+                    .projects
+                    .clone()
+                    .into_values()
+                    .map(PickableItem::from_project)
+                    .collect();
+
+                pickable_items.extend(
+                    entities
+                        .tasks
+                        .clone()
+                        .into_values()
+                        .map(PickableItem::from_task),
+                );
+
+                match picker.pick(pickable_items) {
+                    Ok(pickable_item_id) => match pickable_item_id.kind {
+                        PickableItemKind::TimeEntry => (None, None),
+                        PickableItemKind::Project => {
+                            (entities.projects.get(&pickable_item_id.id).cloned(), None)
+                        }
+                        PickableItemKind::Task => {
+                            let task = entities.tasks.get(&pickable_item_id.id).cloned().unwrap();
+                            (Some(task.clone().project), Some(task))
+                        }
+                    },
+
+                    Err(_) => (None, None),
+                }
+            }
+        }
+    };
+
+    // Only ask for billable if the user didn't provide a value AND if the selected project doesn't have a default billable setting.
+    let billable = billable.unwrap_or(project.clone().and_then(|p| p.billable).unwrap_or(
+        utilities::read_from_stdin_with_constraints(
+            "Is your time entry billable? (y/N): ",
+            &yes_or_default_no,
+        ) == "y",
+    ));
 
     TimeEntry {
         billable,
         description,
         workspace_id,
+        project,
+        task,
         ..Default::default()
     }
 }
@@ -34,20 +92,43 @@ fn interactively_create_time_entry(workspace_id: i64) -> TimeEntry {
 impl StartCommand {
     pub async fn execute(
         api_client: impl ApiClient,
-        possible_description: Option<String>,
-        billable: bool,
+        picker: Box<dyn ItemPicker>,
+        description: Option<String>,
+        project_name: Option<String>,
+        billable: Option<bool>,
+        interactive: bool,
     ) -> ResultWithDefaultError<()> {
         StopCommand::execute(&api_client, StopCommandOrigin::StartCommand).await?;
 
         let workspace_id = (api_client.get_user().await?).default_workspace_id;
-        let time_entry_to_create = match possible_description {
-            None => interactively_create_time_entry(workspace_id),
-            Some(description) => TimeEntry {
-                billable,
+        let entities = api_client.get_entities().await?;
+
+        let project = project_name.and_then(|name| {
+            entities
+                .projects
+                .clone()
+                .into_values()
+                .find(|p| p.name.to_lowercase() == name.to_lowercase())
+        });
+
+        let time_entry_to_create = if interactive {
+            interactively_create_time_entry(
+                workspace_id,
+                entities,
+                picker,
                 description,
+                project,
+                billable,
+            )
+        } else {
+            TimeEntry {
+                billable: billable
+                    .unwrap_or(project.clone().and_then(|p| p.billable).unwrap_or(false)),
+                description: description.unwrap_or("".to_string()),
+                project: project.clone(),
                 workspace_id,
                 ..Default::default()
-            },
+            }
         };
 
         let started_entry_id = api_client.create_time_entry(time_entry_to_create).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn main() -> ResultWithDefaultError<()> {
 async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultError<()> {
     let command = args.cmd;
     let get_default_api_client = || get_api_client(args.proxy.clone());
+    let picker = picker::get_picker(args.fzf);
     match command {
         None => RunningTimeEntryCommand::execute(get_default_api_client()?).await?,
         Some(subcommand) => match subcommand {
@@ -59,12 +60,8 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 StopCommand::execute(&get_default_api_client()?, StopCommandOrigin::CommandLine)
                     .await?;
             }
-            Continue { interactive, fzf } => {
-                let picker = if interactive {
-                    Some(picker::get_picker(fzf))
-                } else {
-                    None
-                };
+            Continue { interactive } => {
+                let picker = if interactive { Some(picker) } else { None };
                 ContinueCommand::execute(get_default_api_client()?, picker).await?
             }
             List { number } => ListCommand::execute(get_default_api_client()?, number).await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,10 +69,21 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 RunningTimeEntryCommand::execute(get_default_api_client()?).await?
             }
             Start {
+                interactive,
                 billable,
                 description,
-                project: _,
-            } => StartCommand::execute(get_default_api_client()?, description, billable).await?,
+                project,
+            } => {
+                StartCommand::execute(
+                    get_default_api_client()?,
+                    picker,
+                    description,
+                    project,
+                    billable,
+                    interactive,
+                )
+                .await?
+            }
             Auth { api_token } => {
                 let credentials = Credentials { api_token };
                 let api_client = V9ApiClient::from_credentials(credentials, args.proxy)?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -59,6 +59,7 @@ pub struct Project {
     pub at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub color: String,
+    pub billable: Option<bool>,
 }
 
 lazy_static! {
@@ -165,6 +166,7 @@ pub struct Task {
     pub id: i64,
     pub name: String,
     pub workspace_id: i64,
+    pub project: Project,
 }
 
 impl TimeEntry {

--- a/src/picker/fzf.rs
+++ b/src/picker/fzf.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-use super::PickableItemId;
+use super::PickableItemKey;
 
 pub struct FzfPicker;
 
@@ -21,15 +21,15 @@ fn format_as_fzf_input(items: &[PickableItem]) -> String {
         .fold("".to_string(), |acc, item| acc + item.as_str() + "\n")
 }
 
-fn create_element_hash_map(items: &[PickableItem]) -> HashMap<String, PickableItemId> {
+fn create_element_hash_map(items: &[PickableItem]) -> HashMap<String, PickableItemKey> {
     items
         .iter()
-        .map(|item| (item.formatted.clone(), item.id.clone()))
+        .map(|item| (item.formatted.clone(), item.key.clone()))
         .collect()
 }
 
 impl ItemPicker for FzfPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId> {
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemKey> {
         let mut command = Command::new("fzf");
         command
             .arg("-n2..")

--- a/src/picker/fzf.rs
+++ b/src/picker/fzf.rs
@@ -10,6 +10,8 @@ use std::io;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+use super::PickableItemId;
+
 pub struct FzfPicker;
 
 fn format_as_fzf_input(items: &[PickableItem]) -> String {
@@ -19,15 +21,15 @@ fn format_as_fzf_input(items: &[PickableItem]) -> String {
         .fold("".to_string(), |acc, item| acc + item.as_str() + "\n")
 }
 
-fn create_element_hash_map(items: &[PickableItem]) -> HashMap<String, i64> {
+fn create_element_hash_map(items: &[PickableItem]) -> HashMap<String, PickableItemId> {
     items
         .iter()
-        .map(|item| (item.formatted.clone(), item.id))
-        .collect::<HashMap<String, i64>>()
+        .map(|item| (item.formatted.clone(), item.id.clone()))
+        .collect()
 }
 
 impl ItemPicker for FzfPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<i64> {
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId> {
         let mut command = Command::new("fzf");
         command
             .arg("-n2..")
@@ -51,7 +53,7 @@ impl ItemPicker for FzfPicker {
                                 utilities::remove_trailing_newline(user_selected_string);
                             let selected_item =
                                 possible_elements.get(&selected_item_index).unwrap();
-                            Ok(*selected_item)
+                            Ok(selected_item.clone())
                         }
                         // This is copied from zoxide's fzf handler.
                         // https://github.com/rohankumardubey/zoxide/blob/main/src/util.rs

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -7,8 +7,21 @@ use crate::models;
 
 use models::{ResultWithDefaultError, TimeEntry};
 
+#[derive(Clone)]
+pub struct PickableItemId {
+    pub id: i64,
+    pub kind: PickableItemKind,
+}
+
+#[derive(Clone, Copy)]
+pub enum PickableItemKind {
+    TimeEntry,
+    Project,
+    Task,
+}
+
 pub struct PickableItem {
-    id: i64,
+    id: PickableItemId,
     formatted: String,
 }
 
@@ -26,14 +39,17 @@ impl PickableItem {
         );
 
         PickableItem {
-            id: time_entry.id,
+            id: PickableItemId {
+                id: time_entry.id,
+                kind: PickableItemKind::TimeEntry,
+            },
             formatted: formatted_time_entry,
         }
     }
 }
 
 pub trait ItemPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<i64>;
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId>;
 }
 
 #[cfg(unix)]

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -13,7 +13,7 @@ use crate::models::Task;
 use models::{ResultWithDefaultError, TimeEntry};
 
 #[derive(Clone)]
-pub struct PickableItemId {
+pub struct PickableItemKey {
     pub id: i64,
     pub kind: PickableItemKind,
 }
@@ -26,11 +26,11 @@ pub enum PickableItemKind {
 }
 
 pub struct PickableItem {
-    id: PickableItemId,
+    key: PickableItemKey,
     formatted: String,
 }
 
-impl FromStr for PickableItemId {
+impl FromStr for PickableItemKey {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -48,11 +48,11 @@ impl FromStr for PickableItemId {
             Err(_) => return Err(()),
         };
 
-        Ok(PickableItemId { kind, id })
+        Ok(PickableItemKey { kind, id })
     }
 }
 
-impl Display for PickableItemId {
+impl Display for PickableItemKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -81,7 +81,7 @@ impl PickableItem {
         );
 
         PickableItem {
-            id: PickableItemId {
+            key: PickableItemKey {
                 id: time_entry.id,
                 kind: PickableItemKind::TimeEntry,
             },
@@ -100,7 +100,7 @@ impl PickableItem {
         );
 
         PickableItem {
-            id: PickableItemId {
+            key: PickableItemKey {
                 id: project.id,
                 kind: PickableItemKind::Project,
             },
@@ -120,7 +120,7 @@ impl PickableItem {
         );
 
         PickableItem {
-            id: PickableItemId {
+            key: PickableItemKey {
                 id: task.id,
                 kind: PickableItemKind::Task,
             },
@@ -130,7 +130,7 @@ impl PickableItem {
 }
 
 pub trait ItemPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId>;
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemKey>;
 }
 
 #[cfg(unix)]

--- a/src/picker/mod.rs
+++ b/src/picker/mod.rs
@@ -4,7 +4,8 @@ mod skim;
 
 use crate::constants;
 use crate::models;
-
+use crate::models::Project;
+use crate::models::Task;
 use models::{ResultWithDefaultError, TimeEntry};
 
 #[derive(Clone)]
@@ -44,6 +45,45 @@ impl PickableItem {
                 kind: PickableItemKind::TimeEntry,
             },
             formatted: formatted_time_entry,
+        }
+    }
+
+    pub fn from_project(project: Project) -> PickableItem {
+        let formatted_project = format!(
+            "{}{}",
+            project.name,
+            match project.client.clone() {
+                Some(c) => format!(" - Client: {}", c.name),
+                None => "".to_string(),
+            }
+        );
+
+        PickableItem {
+            id: PickableItemId {
+                id: project.id,
+                kind: PickableItemKind::Project,
+            },
+            formatted: formatted_project,
+        }
+    }
+
+    pub fn from_task(task: Task) -> PickableItem {
+        let formatted_task = format!(
+            "{} (Task: {}){}",
+            task.project.name,
+            task.name,
+            match task.project.client.clone() {
+                Some(c) => format!(" - Client: {}", c.name),
+                None => "".to_string(),
+            }
+        );
+
+        PickableItem {
+            id: PickableItemId {
+                id: task.id,
+                kind: PickableItemKind::Task,
+            },
+            formatted: formatted_task,
         }
     }
 }

--- a/src/picker/skim.rs
+++ b/src/picker/skim.rs
@@ -3,7 +3,7 @@ use crate::models;
 use crate::picker;
 use error::PickerError;
 use models::ResultWithDefaultError;
-use picker::{ItemPicker, PickableItem};
+use picker::{ItemPicker, PickableItem, PickableItemId};
 use skim::prelude::*;
 
 pub struct SkimPicker;
@@ -38,7 +38,7 @@ impl SkimItem for PickableItem {
 }
 
 impl ItemPicker for SkimPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemKind> {
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId> {
         let (options, source) = get_skim_configuration(items);
         let output = Skim::run_with(&options, Some(source));
 
@@ -51,12 +51,14 @@ impl ItemPicker for SkimPicker {
                     let selectable_items = item
                         .selected_items
                         .iter()
-                        .map(|selected_items| selected_items.output().parse::<i64>().unwrap())
-                        .collect::<Vec<PickableItemKind>>();
+                        .map(|selected_items| {
+                            selected_items.output().parse::<PickableItemId>().unwrap()
+                        })
+                        .collect::<Vec<PickableItemId>>();
 
                     match selectable_items.first() {
                         None => Err(Box::new(PickerError::Generic)),
-                        Some(id) => Ok(*id),
+                        Some(id) => Ok(id.clone()),
                     }
                 }
             }

--- a/src/picker/skim.rs
+++ b/src/picker/skim.rs
@@ -38,7 +38,7 @@ impl SkimItem for PickableItem {
 }
 
 impl ItemPicker for SkimPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<i64> {
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemKind> {
         let (options, source) = get_skim_configuration(items);
         let output = Skim::run_with(&options, Some(source));
 
@@ -52,7 +52,7 @@ impl ItemPicker for SkimPicker {
                         .selected_items
                         .iter()
                         .map(|selected_items| selected_items.output().parse::<i64>().unwrap())
-                        .collect::<Vec<i64>>();
+                        .collect::<Vec<PickableItemKind>>();
 
                     match selectable_items.first() {
                         None => Err(Box::new(PickerError::Generic)),

--- a/src/picker/skim.rs
+++ b/src/picker/skim.rs
@@ -3,7 +3,7 @@ use crate::models;
 use crate::picker;
 use error::PickerError;
 use models::ResultWithDefaultError;
-use picker::{ItemPicker, PickableItem, PickableItemId};
+use picker::{ItemPicker, PickableItem, PickableItemKey};
 use skim::prelude::*;
 
 pub struct SkimPicker;
@@ -33,12 +33,12 @@ impl SkimItem for PickableItem {
     }
 
     fn output(&self) -> Cow<str> {
-        Cow::from(self.id.to_string())
+        Cow::from(self.key.to_string())
     }
 }
 
 impl ItemPicker for SkimPicker {
-    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemId> {
+    fn pick(&self, items: Vec<PickableItem>) -> ResultWithDefaultError<PickableItemKey> {
         let (options, source) = get_skim_configuration(items);
         let output = Skim::run_with(&options, Some(source));
 
@@ -52,9 +52,9 @@ impl ItemPicker for SkimPicker {
                         .selected_items
                         .iter()
                         .map(|selected_items| {
-                            selected_items.output().parse::<PickableItemId>().unwrap()
+                            selected_items.output().parse::<PickableItemKey>().unwrap()
                         })
-                        .collect::<Vec<PickableItemId>>();
+                        .collect::<Vec<PickableItemKey>>();
 
                     match selectable_items.first() {
                         None => Err(Box::new(PickerError::Generic)),


### PR DESCRIPTION
Closes #47

This changes the API so that:

- `--fzf` is now globally configurable
- The prompts will only ever appear in `toggl start` if you are passing `-i`
- Interactive mode will only prompt field you haven't explicitly passed to the command line (if you pass `--description foo` it will just use that instead of asking for a description)
- All default values come from the plain default time entry, but in the future they will be configurable, courtesy of #45 