### PR TITLE
Integrate configuration into tracking

### DIFF
--- a/src/config/active.rs
+++ b/src/config/active.rs
@@ -6,8 +6,7 @@ impl ConfigActiveCommand {
     pub async fn execute() -> ResultWithDefaultError<()> {
         let config_path = super::locate::locate_config_path()?;
         let track_config = super::parser::get_config_from_file(config_path)?;
-        let current_dir = std::env::current_dir()?;
-        println!("{}", track_config.get_branch_config_for_dir(&current_dir));
+        println!("{}", track_config.get_active_config()?);
         Ok(())
     }
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -6,6 +6,7 @@ use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ConfigError;
+use crate::models::ResultWithDefaultError;
 use crate::utilities;
 
 /// BranchConfig optionally determines workspace, description, project, task,
@@ -504,5 +505,9 @@ impl TrackConfig {
     pub fn get_branch_config_for_dir(&self, dir: &PathBuf) -> &BranchConfig {
         let branch = utilities::get_git_branch_for_dir(dir);
         self.get_branch_config(branch.as_deref())
+    }
+    pub fn get_active_config(&self) -> ResultWithDefaultError<&BranchConfig> {
+        let current_dir = std::env::current_dir()?;
+        return Ok(self.get_branch_config_for_dir(&current_dir));
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 pub type ResultWithDefaultError<T> = Result<T, Box<dyn std::error::Error>>;
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Entities {
     pub time_entries: Vec<TimeEntry>,
     pub projects: HashMap<i64, Project>,


### PR DESCRIPTION
## :star2: What does this PR do?

- 📦 Add `get_active_config` to TrackConfig
- 🌟 Prefill time-entry using active config

## :bug: Recommendations for testing

- This PR implements part 3 of the spec described in #45.
- We use the active configuration implemented in #53 as defaults for
  our time-entry.
- Not sure if we should do the following in this PR or as a follow-up.
  - Create missing entities (projects and tasks) if they don't exist.
  - Fetch workspaces as part of `Entities` and implement default matching
    for configuration.

### Commands affected

```console
$ toggl config active
$ toggl start
$ toggl start --interactive
```

### See it in action

https://github.com/watercooler-labs/toggl-cli/assets/1716853/d6772c86-0c4d-4128-9564-1fd96a22a7cb

## :memo: Links to relevant issues/docs

See #45 for the configuration proposal.

## :speech_balloon: Summarise how you feel about this PR with a gif/image

![emma-darcy-rhaenyra](https://github.com/watercooler-labs/toggl-cli/assets/1716853/fd05ee2c-4869-4273-8568-ee22ba325747)
