### PR TITLE
🩹 Fix path output when stdout is not terminal

### DIFF
--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
 };
 
@@ -22,6 +22,9 @@ pub fn read_from_stdin(text: &str) -> String {
 }
 
 pub fn simplify_config_path_for_display(dir: &Path) -> String {
+    if !std::io::stdout().is_terminal() {
+        return dir.display().to_string();
+    }
     let base_dirs = BaseDirs::new().unwrap();
     let local_config_base_path = base_dirs.config_local_dir().to_str().unwrap();
     let mut display_config_path = dir.to_str().unwrap().to_string();


### PR DESCRIPTION
## :star2: What does this PR do?

- Adds a check using `std::io::stdout().is_terminal()` to decide
  if we should log the simplified or the full path.

## :bug: Recommendations for testing

![image](https://github.com/watercooler-labs/toggl-cli/assets/1716853/1995d479-a25f-4e11-9b37-7281a3259a25)

```console
$ toggl config --path # logs the simplified path
$ cat "$(toggl config --path)" # correctly logs the config toml
```

### Commands affected

```console
$ toggl config init
$ toggl config --delete
$ toggl config --path
```

## :memo: Links to relevant issues/docs

Closes #63

## :speech_balloon: Summarise how you feel about this PR with a gif/image

![zelda-cucco](https://github.com/watercooler-labs/toggl-cli/assets/1716853/c16d5b9f-56d4-43c7-b755-5152b33b876e)
