### PR TITLE
Canonicalize path of Git root.

### DIFF
--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -373,7 +373,10 @@ fn resolve_macro(base_dir: &Path, instruction: Macro) -> ResultWithDefaultError<
                             .nth(1)
                             .expect("Failed to resolve git worktree root")
                             .trim();
-                        let git_root = PathBuf::from(git_dir);
+
+                        let git_root = std::fs::canonicalize(git_dir)
+                            .map(PathBuf::from)
+                            .expect("Failed to canonicalize Git root directory");
 
                         // git_root stores the path to the main repository in the following format
                         // gitdir: /path/to/main/repo/.git/worktrees/<worktree_name>


### PR DESCRIPTION
When inside a Git worktree, the path to root can be relative, e.g., ../.git/modules/foo. When this happens, the attempt to get the root's parent's parent's parent fails to unwrap at config/model.rs:389, causing a panic. If we canonicalize the path first, this doesn't happen.