### PR TITLE
Add support for setting workspace using the config

### DIFF
--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -48,6 +48,13 @@ pub struct NetworkTask {
     pub project_id: i64,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NetworkWorkspace {
+    pub id: i64,
+    pub name: String,
+    pub admin: bool,
+}
+
 impl From<TimeEntry> for NetworkTimeEntry {
     fn from(value: TimeEntry) -> Self {
         NetworkTimeEntry {

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -110,6 +110,12 @@ impl StartCommand {
         let track_config = config::parser::get_config_from_file(config_path)?;
         let default_time_entry = track_config.get_default_entry(entities.clone())?;
 
+        let workspace_id = if default_time_entry.workspace_id != -1 {
+            default_time_entry.workspace_id
+        } else {
+            workspace_id
+        };
+
         let project = project_name
             .and_then(|name| {
                 entities

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -136,7 +136,7 @@ impl StartCommand {
             interactively_create_time_entry(
                 default_time_entry,
                 workspace_id,
-                entities,
+                entities.clone(),
                 picker,
                 description,
                 project,
@@ -152,15 +152,15 @@ impl StartCommand {
             }
         };
 
-        let started_entry_id = api_client.create_time_entry(time_entry_to_create).await?;
-        let entities = api_client.get_entities().await?;
-        let started_entry = entities
-            .time_entries
-            .iter()
-            .find(|te| te.id == started_entry_id)
-            .unwrap();
+        let started_entry_id = api_client
+            .create_time_entry(time_entry_to_create.clone())
+            .await;
+        if started_entry_id.is_err() {
+            println!("{}", "Failed to start time entry".red());
+            return Err(started_entry_id.err().unwrap());
+        }
 
-        println!("{}\n{}", "Time entry started".green(), started_entry);
+        println!("{}\n{}", "Time entry started".green(), time_entry_to_create);
 
         Ok(())
     }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -546,8 +546,19 @@ impl TrackConfig {
                 .find(|t| t.name == name && t.project.id == project_id.unwrap())
         });
 
+        let workspace_id = config.workspace.as_ref().map_or(
+            // Default to -1 if workspace is not set
+            Ok(-1),
+            |name| {
+                entities.workspace_id_for_name(name).ok_or_else(|| {
+                    Box::new(ConfigError::WorkspaceNotFound(name.clone()))
+                        as Box<dyn std::error::Error + Send>
+                })
+            },
+        )?;
+
         let time_entry = TimeEntry {
-            // TODO: Add support for workspace
+            workspace_id,
             description: config.description.clone().unwrap_or_default(),
             billable: config.billable,
             tags: config.tags.clone().unwrap_or_default(),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,6 +23,7 @@ pub const CONFIG_FILE_NOT_FOUND_ERROR: &str = "No config file found";
 pub const CONFIG_PARSE_ERROR: &str = "Failed to parse config file";
 pub const CONFIG_UNRECOGNIZED_MACRO_ERROR: &str = "Unrecognized macro in config file";
 pub const CONFIG_SHELL_MACRO_RESOLUTION_ERROR: &str = "Failed to resolve shell macro";
+pub const CONFIG_INVALID_WORKSPACE_ERROR: &str = "Workspace not found";
 pub const NO_PROJECT: &str = "No Project";
 pub const NO_DESCRIPTION: &str = "(no description)";
 pub const DIRECTORY_NOT_FOUND_ERROR: &str = "Directory not found";

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,7 @@ pub enum ConfigError {
     FileNotFound,
     UnrecognizedMarco(String),
     ShellResolution(String, String),
+    WorkspaceNotFound(String),
 }
 
 impl Display for ConfigError {
@@ -133,6 +134,15 @@ impl Display for ConfigError {
                     output_or_error.red().bold(),
                     "Command".yellow(),
                     command.yellow().bold(),
+                )
+            }
+            ConfigError::WorkspaceNotFound(workspace) => {
+                format!(
+                    "{}: {}\n{}\n{}",
+                    constants::CONFIG_INVALID_WORKSPACE_ERROR.red().bold(),
+                    workspace.red().bold(),
+                    "Check your configuration file".yellow().bold(),
+                    "toggl config --edit".yellow().bold(),
                 )
             }
         };

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,6 +17,7 @@ pub struct Entities {
     pub projects: HashMap<i64, Project>,
     pub tasks: HashMap<i64, Task>,
     pub clients: HashMap<i64, Client>,
+    pub workspaces: Vec<Workspace>,
 }
 
 impl Entities {
@@ -61,6 +62,13 @@ pub struct Project {
     pub created_at: DateTime<Utc>,
     pub color: String,
     pub billable: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Workspace {
+    pub id: i64,
+    pub name: String,
+    pub admin: bool,
 }
 
 lazy_static! {

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,6 +24,13 @@ impl Entities {
     pub fn running_time_entry(&self) -> Option<TimeEntry> {
         self.time_entries.iter().find(|te| te.is_running()).cloned()
     }
+
+    pub fn workspace_id_for_name(&self, name: &str) -> Option<i64> {
+        self.workspaces
+            .iter()
+            .find(|w| w.name == name)
+            .map(|w| w.id)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
## What does this PR do?

- 📥 Use workspace specified in config

If workspace name is specified in the config, we use it while creating a new time-entry.
If the workspace name cannot be matched against the fetched workspaces from the API, we raise an error.
If workspace name is not specified in the config, we use the default workspace.

> Note: At the moment I don't have access to multiple workspaces, it's a paid feature.
> So, I'm unable to test this feature comprehensively. I've tested it with the workspace I have access to.
> Both by specifying the workspace name explicitly in the config and by omitting it.

### Default behaviour (no workspace set)

[![asciicast](https://asciinema.org/a/ejJ6Rw0KDnzoj2lBahQwBjdXO.svg)](https://asciinema.org/a/ejJ6Rw0KDnzoj2lBahQwBjdXO)

### Workspace name specified

[![asciicast](https://asciinema.org/a/oKoceoKUIsaYHntcyC6AUDzFf.svg)](https://asciinema.org/a/oKoceoKUIsaYHntcyC6AUDzFf)

### Invalid workspace name

[![asciicast](https://asciinema.org/a/dXkBEYCCRsXQS91gZNtUmbxX5.svg)](https://asciinema.org/a/dXkBEYCCRsXQS91gZNtUmbxX5)

### Gif

![kermit-kermit-the-frog](https://github.com/user-attachments/assets/09b8b493-64be-4d7d-8ce5-ac2ae3771d96)

### Context

- Closes #79
