### PR TITLE
Support reading token from environment variable

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -14,7 +14,7 @@ impl AuthenticationCommand {
     pub async fn execute<W: Write>(
         mut writer: W,
         api_client: impl ApiClient,
-        credentials_storage: impl CredentialsStorage,
+        credentials_storage: Box<dyn CredentialsStorage>,
     ) -> ResultWithDefaultError<()> {
         let user = api_client.get_user().await?;
         credentials_storage.persist(user.api_token)?;
@@ -90,7 +90,7 @@ mod tests {
         // Arrange
         let mut output = Vec::new();
         let api_client = create_working_api_client();
-        let credentials_storage = create_working_credentials_storage();
+        let credentials_storage = Box::new(create_working_credentials_storage());
 
         // Act
         let result =
@@ -105,7 +105,7 @@ mod tests {
         // Arrange
         let mut output = Vec::new();
         let api_client = create_working_api_client();
-        let credentials_storage = create_working_credentials_storage();
+        let credentials_storage = Box::new(create_working_credentials_storage());
 
         // Act
         let _ = AuthenticationCommand::execute(&mut output, api_client, credentials_storage).await;
@@ -127,7 +127,7 @@ mod tests {
         // Arrange
         let mut output = Vec::new();
         let api_client = create_failing_api_client();
-        let credentials_storage = create_working_credentials_storage();
+        let credentials_storage = Box::new(create_working_credentials_storage());
 
         // Act
         let result =
@@ -142,7 +142,7 @@ mod tests {
         // Arrange
         let mut output = Vec::new();
         let api_client = create_working_api_client();
-        let credentials_storage = create_failing_credentials_storage();
+        let credentials_storage = Box::new(create_failing_credentials_storage());
 
         // Act
         let result =

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -75,5 +75,5 @@ fn get_first_stopped_time_entry(
         None => 0,
         Some(_) => 1,
     };
-    return time_entries.get(continue_entry_index).cloned();
+    time_entries.get(continue_entry_index).cloned()
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -523,7 +523,7 @@ impl TrackConfig {
     }
     pub fn get_active_config(&self) -> ResultWithDefaultError<&BranchConfig> {
         let current_dir = std::env::current_dir().expect("Failed to get current directory");
-        return Ok(self.get_branch_config_for_dir(&current_dir));
+        Ok(self.get_branch_config_for_dir(&current_dir))
     }
     pub fn get_default_entry(&self, entities: Entities) -> ResultWithDefaultError<TimeEntry> {
         let config = self.get_active_config()?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,9 +13,11 @@ pub const CREDENTIALS_WRITE_ERROR: &str =
 pub const CREDENTIALS_DELETE_ERROR: &str =
     "An unknown error occurred while deleting your credentials.";
 pub const CREDENTIALS_EMPTY_ERROR: &str =
-    "Please set your API token first by calling toggl auth <API_TOKEN>.";
+    "Please set your API token first by calling toggl auth <API_TOKEN>. Or export it as TOGGL_API_TOKEN.";
 pub const CREDENTIALS_FIND_TOKEN_MESSAGE: &str = "You can find your API token at";
 pub const CREDENTIALS_FIND_TOKEN_LINK: &str = "https://track.toggl.com/profile";
+pub const CREDENTIALS_OVERRIDE_ERROR: &str =
+    "You have set TOGGL_API_TOKEN in your environment. Unset it to update or delete your saved credentials.";
 
 pub const FZF_NOT_INSTALLED_ERROR: &str = "fzf could not be found. Is it installed?";
 pub const OPERATION_CANCELLED: &str = "Operation cancelled";

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,7 @@ pub enum StorageError {
     Write,
     Delete,
     Unknown,
+    EnvironmentOverride,
 }
 
 impl Display for StorageError {
@@ -61,6 +62,9 @@ impl Display for StorageError {
                     constants::OUTDATED_APP_ERROR_MESSAGE.blue().bold(),
                     constants::ISSUE_LINK.blue().bold().underline()
                 )
+            }
+            StorageError::EnvironmentOverride => {
+                format!("{}", constants::CREDENTIALS_OVERRIDE_ERROR.red())
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ use commands::list::ListCommand;
 use commands::running::RunningTimeEntryCommand;
 use commands::start::StartCommand;
 use commands::stop::{StopCommand, StopCommandOrigin};
-use credentials::{Credentials, CredentialsStorage, KeyringStorage};
-use keyring::Entry;
+use credentials::get_storage;
+use credentials::Credentials;
 use models::ResultWithDefaultError;
 use std::io;
 use structopt::StructOpt;
@@ -140,10 +140,4 @@ fn get_api_client(proxy: Option<String>) -> ResultWithDefaultError<impl ApiClien
         Ok(credentials) => V9ApiClient::from_credentials(credentials, proxy),
         Err(err) => Err(err),
     }
-}
-
-fn get_storage() -> impl CredentialsStorage {
-    let keyring = Entry::new("togglcli", "default")
-        .unwrap_or_else(|err| panic!("Couldn't create credentials_storage: {err}"));
-    KeyringStorage::new(keyring)
 }


### PR DESCRIPTION
## What does this PR do?

- 🌳 Read token from TOGGL_API_TOKEN environment variable
- Environment store overrides keyring store, write and delete operations
  are disabled for the keyring store.
- This should allow linux users to authenticate and persist their credentials
  in their shell configuration, until we figure out the keyring crate's persistence issue

### Gif

![linux-penguin](https://github.com/user-attachments/assets/9ab1ade4-3270-4c6a-8a28-2671a4b739bb)

### Context

Closes #81
