### PR TITLE
Fix configuration use in start command

### DIFF
--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -106,9 +106,10 @@ impl StartCommand {
         let workspace_id = (api_client.get_user().await?).default_workspace_id;
         let entities = api_client.get_entities().await?;
 
-        let config_path = config::locate::locate_config_path()?;
-        let track_config = config::parser::get_config_from_file(config_path)?;
-        let default_time_entry = track_config.get_default_entry(entities.clone())?;
+        let default_time_entry = config::locate::locate_config_path()
+            .and_then(config::parser::get_config_from_file)
+            .and_then(|track_config| track_config.get_default_entry(entities.clone()))
+            .unwrap_or_else(|_| TimeEntry::default());
 
         let workspace_id = if default_time_entry.workspace_id != -1 {
             default_time_entry.workspace_id

--- a/src/config/fixtures/default.toml
+++ b/src/config/fixtures/default.toml
@@ -14,11 +14,11 @@
 
 # Description (optional, default="")
 # Accepts any string template with our macros in them
-description = "🔨 {{branch}}"
+description = "🔨 {{current_dir}}"
 
 # Project (optional, default=No project)
 # Accepts any string template with our macros in them
-project = "{{git_root}}"
+project = "{{current_dir}}"
 
 # Task (optional, default=No task)
 # task = "Some task"


### PR DESCRIPTION
## What does this PR do?

- Start command should work even if config doesn't exist

  ```rust
  let config_path = config::locate::locate_config_path()?;
  let track_config = config::parser::get_config_from_file(config_path)?;
  let default_time_entry = track_config.get_default_entry(entities.clone())?;
  ```

  These established a hard dependency on the `config` infrastructure.
  We fix this, by only following the config code branch if a configuration
  path can be located.

  **Caveat**: This silences the error if a configuration is found but cannot
  be parsed. I'm treading on the side of simplicity over correctness here.
  In future we might treat the configuration error as a critical error.

- Simplify default config file
  Previously our default config for `toggl config --init` enforced
  the use of git.
  Such that, even for non-vcs tracked paths we would use a configuration
  that tries to resolve it's values from `git` which errors out.

  I think in general the wildcard match rule `[*]` should be agnostic of vcs.

  This changes the default to use `{{current_dir}}` which is guarenteed
  to work at any path the `toggl` command is invoked as is a much better
  default.

**Note**: This is my configuration block for the wildcard match.

```toml
['*']
tags = ["{{current_dir}}"]
billable = true
```

## Context

Closes #84
