### PR TITLE
👾 Allow tags to be set in `start` command

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -52,6 +52,12 @@ pub enum Command {
             help = "Exact name of the project you want the time entry to be associated with"
         )]
         project: Option<String>,
+        #[structopt(
+            short,
+            long,
+            help = "Space separated list of tags to associate with the time entry, e.g. 'tag1 tag2 tag3'"
+        )]
+        tags: Option<Vec<String>>,
         #[structopt(short, long)]
         billable: bool,
     },

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -23,6 +23,7 @@ fn interactively_create_time_entry(
     picker: Box<dyn ItemPicker>,
     description: String,
     project: Option<Project>,
+    tags: Vec<String>,
     billable: bool,
 ) -> TimeEntry {
     let yes_or_default_no = [
@@ -87,6 +88,7 @@ fn interactively_create_time_entry(
         description,
         workspace_id,
         project,
+        tags,
         task,
         ..default_time_entry
     }
@@ -98,6 +100,7 @@ impl StartCommand {
         picker: Box<dyn ItemPicker>,
         description: Option<String>,
         project_name: Option<String>,
+        tags: Option<Vec<String>>,
         billable: bool,
         interactive: bool,
     ) -> ResultWithDefaultError<()> {
@@ -127,6 +130,8 @@ impl StartCommand {
             })
             .or(default_time_entry.project.clone());
 
+        let tags = tags.unwrap_or(default_time_entry.tags.clone());
+
         let billable = billable
             || default_time_entry.billable
             || project.clone().and_then(|p| p.billable).unwrap_or(false);
@@ -141,6 +146,7 @@ impl StartCommand {
                 picker,
                 description,
                 project,
+                tags,
                 billable,
             )
         } else {
@@ -148,6 +154,7 @@ impl StartCommand {
                 billable,
                 description,
                 project,
+                tags,
                 workspace_id,
                 ..default_time_entry
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,12 +88,14 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 billable,
                 description,
                 project,
+                tags,
             } => {
                 StartCommand::execute(
                     get_default_api_client()?,
                     picker,
                     description,
                     project,
+                    tags,
                     billable,
                     interactive,
                 )


### PR DESCRIPTION
## What does this PR do?

Add support for `--tags` (short `-t`) to the `toggl start` command.
This accepts a space-separated list of tags to apply to the time entry.

### Usage

```bash
toggl start 'Add initial database' --tags code dev --project watercooler-labs
```

[![asciicast](https://asciinema.org/a/ESgBGQ5ZMf3yJ4yliB8JIhz6z.svg)](https://asciinema.org/a/ESgBGQ5ZMf3yJ4yliB8JIhz6z)

> **Note**: `--tags` will override any tags configured in the directory configuration.

## Gif

![tag](https://github.com/user-attachments/assets/e5d76a4b-272b-4aa8-a411-c313323c1dd0)

## Context

Closes #83
