### PR TITLE
feat: `toggl list --json` flag

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -27,6 +27,8 @@ pub enum Command {
         number: Option<usize>,
         #[structopt(subcommand)]
         entity: Option<Entity>,
+        #[structopt(short, long, help = "Output in JSON format")]
+        json: bool,
     },
     Running,
     Stop,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -25,10 +25,10 @@ pub enum Command {
     List {
         #[structopt(short, long)]
         number: Option<usize>,
-        #[structopt(subcommand)]
-        entity: Option<Entity>,
         #[structopt(short, long, help = "Output in JSON format")]
         json: bool,
+        #[structopt(subcommand)]
+        entity: Option<Entity>,
     },
     Running,
     Stop,
@@ -88,8 +88,14 @@ pub enum Command {
 }
 #[derive(Debug, StructOpt)]
 pub enum Entity {
-    Project,
-    TimeEntry,
+    Project {
+        #[structopt(short, long, help = "Output in JSON format")]
+        json: bool,
+    },
+    TimeEntry {
+        #[structopt(short, long, help = "Output in JSON format")]
+        json: bool,
+    },
 }
 #[derive(Debug, StructOpt)]
 pub enum ConfigSubCommand {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -30,23 +30,22 @@ impl ListCommand {
                 // TODO: better error handling for writeln!
                 match entity.unwrap_or(Entity::TimeEntry) {
                     Entity::TimeEntry => {
+                        let entries = entities
+                            .time_entries
+                            .iter()
+                            .take(count.unwrap_or(usize::MAX));
+
                         if json.unwrap_or(false) {
-                            let entries: Vec<_> = entities
-                                .time_entries
-                                .iter()
-                                .take(count.unwrap_or(usize::MAX))
-                                .collect();
-                            let json_string = serde_json::to_string_pretty(&entries).unwrap();
+                            let entries = entries.collect::<Vec<_>>();
+                            let json_string = serde_json::to_string_pretty(&entries)
+                                .expect("failed to serialize time entries to JSON");
                             writeln!(handle, "{json_string}").expect("failed to print");
                         } else {
-                            entities
-                                .time_entries
-                                .iter()
-                                .take(count.unwrap_or(usize::MAX))
-                                .for_each(|time_entry| {
-                                    writeln!(handle, "{time_entry}").expect("failed to print")
-                                });
+                            entries.for_each(|time_entry| {
+                                writeln!(handle, "{time_entry}").expect("failed to print")
+                            });
                         }
+
                     }
 
                     Entity::Project => entities

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -52,8 +52,7 @@ impl ListCommand {
                         let json = json_flag || entity_json;
                         let projects = entities
                             .projects
-                            .iter()
-                            .map(|(_, project)| project)
+                            .values()
                             .take(count.unwrap_or(usize::MAX))
                             .collect::<Vec<_>>();
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -12,8 +12,8 @@ impl ListCommand {
     pub async fn execute(
         api_client: impl ApiClient,
         count: Option<usize>,
+        json_flag: bool,
         entity: Option<Entity>,
-        json: Option<bool>,
     ) -> ResultWithDefaultError<()> {
         match api_client.get_entities().await {
             Err(error) => println!(
@@ -28,33 +28,45 @@ impl ListCommand {
                 let mut handle = BufWriter::new(stdout);
 
                 // TODO: better error handling for writeln!
-                match entity.unwrap_or(Entity::TimeEntry) {
-                    Entity::TimeEntry => {
+                match entity.unwrap_or(Entity::TimeEntry { json: false }) {
+                    Entity::TimeEntry { json: entity_json } => {
+                        let json = json_flag || entity_json;
                         let entries = entities
                             .time_entries
                             .iter()
-                            .take(count.unwrap_or(usize::MAX));
+                            .take(count.unwrap_or(usize::MAX))
+                            .collect::<Vec<_>>();
 
-                        if json.unwrap_or(false) {
-                            let entries = entries.collect::<Vec<_>>();
+                        if json {
                             let json_string = serde_json::to_string_pretty(&entries)
                                 .expect("failed to serialize time entries to JSON");
                             writeln!(handle, "{json_string}").expect("failed to print");
                         } else {
-                            entries.for_each(|time_entry| {
+                            entries.iter().for_each(|time_entry| {
                                 writeln!(handle, "{time_entry}").expect("failed to print")
                             });
                         }
-
                     }
 
-                    Entity::Project => entities
-                        .projects
-                        .iter()
-                        .take(count.unwrap_or(usize::MAX))
-                        .for_each(|(_, projects)| {
-                            writeln!(handle, "{projects}").expect("failed to print")
-                        }),
+                    Entity::Project { json: entity_json } => {
+                        let json = json_flag || entity_json;
+                        let projects = entities
+                            .projects
+                            .iter()
+                            .map(|(_, project)| project)
+                            .take(count.unwrap_or(usize::MAX))
+                            .collect::<Vec<_>>();
+
+                        if json {
+                            let json_string = serde_json::to_string_pretty(&projects)
+                                .expect("failed to serialize projects to JSON");
+                            writeln!(handle, "{json_string}").expect("failed to print");
+                        } else {
+                            projects.iter().for_each(|project| {
+                                writeln!(handle, "{project}").expect("failed to print")
+                            });
+                        }
+                    }
                 };
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,10 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
 
             List {
                 number,
-                entity,
                 json,
+                entity,
             } => {
-                ListCommand::execute(get_default_api_client()?, number, entity, Some(json)).await?
+                ListCommand::execute(get_default_api_client()?, number, json, entity).await?
             }
 
             Current | Running => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,7 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 number,
                 json,
                 entity,
-            } => {
-                ListCommand::execute(get_default_api_client()?, number, json, entity).await?
-            }
+            } => ListCommand::execute(get_default_api_client()?, number, json, entity).await?,
 
             Current | Running => {
                 RunningTimeEntryCommand::execute(get_default_api_client()?).await?

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,12 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 ContinueCommand::execute(get_default_api_client()?, picker).await?
             }
 
-            List { number, entity } => {
-                ListCommand::execute(get_default_api_client()?, number, entity).await?
+            List {
+                number,
+                entity,
+                json,
+            } => {
+                ListCommand::execute(get_default_api_client()?, number, entity, Some(json)).await?
             }
 
             Current | Running => {

--- a/src/picker/skim.rs
+++ b/src/picker/skim.rs
@@ -28,11 +28,11 @@ fn get_skim_configuration(items: Vec<PickableItem>) -> (SkimOptions<'static>, Sk
 }
 
 impl SkimItem for PickableItem {
-    fn text(&self) -> Cow<str> {
+    fn text<'a>(&'a self) -> Cow<'a, str> {
         Cow::from(self.formatted.as_str())
     }
 
-    fn output(&self) -> Cow<str> {
+    fn output<'a>(&'a self) -> Cow<'a, str> {
         Cow::from(self.key.to_string())
     }
 }


### PR DESCRIPTION
This add json flag for the `toggl list`, `toggl list project`, and `toggl list time-entry` commands. 

The default behavior is unchanged, i.e. it still outputs in table format.
