### PR TITLE
feat: specify task in `toggl start`

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -70,6 +70,11 @@ pub enum Command {
             help = "Space separated list of tags to associate with the time entry, e.g. 'tag1 tag2 tag3'"
         )]
         tags: Option<Vec<String>>,
+        #[structopt(
+            long,
+            help = "Exact name of the task you want the time entry to be associated with"
+        )]
+        task: Option<String>,
         #[structopt(short, long)]
         billable: bool,
     },

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -85,6 +85,7 @@ fn interactively_create_time_entry(
 }
 
 impl StartCommand {
+    #[allow(clippy::too_many_arguments)]
     pub async fn execute(
         api_client: impl ApiClient,
         picker: Box<dyn ItemPicker>,
@@ -93,6 +94,7 @@ impl StartCommand {
         tags: Option<Vec<String>>,
         billable: bool,
         interactive: bool,
+        task: Option<String>,
     ) -> ResultWithDefaultError<()> {
         StopCommand::execute(&api_client, StopCommandOrigin::StartCommand).await?;
 
@@ -110,15 +112,61 @@ impl StartCommand {
             workspace_id
         };
 
-        let project = project_name
-            .and_then(|name| {
-                entities
-                    .projects
-                    .clone()
-                    .into_values()
-                    .find(|p| p.name == name)
-            })
-            .or(default_time_entry.project.clone());
+        // Look up project by name if provided
+        let project_from_flag = project_name.as_ref().and_then(|name| {
+            entities
+                .projects
+                .clone()
+                .into_values()
+                .find(|p| p.name == *name)
+        });
+
+        // Error if project name was provided but not found
+        if let Some(name) = &project_name {
+            if project_from_flag.is_none() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "Project \"{}\" not found",
+                    name
+                ))));
+            }
+        }
+
+        // Look up task by name if provided
+        let task_obj = task.as_ref().and_then(|task_name| {
+            entities
+                .tasks
+                .clone()
+                .into_values()
+                .find(|t| t.name == *task_name)
+        });
+
+        // Error if task name was provided but not found
+        if let Some(name) = &task {
+            if task_obj.is_none() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "Task \"{}\" not found",
+                    name
+                ))));
+            }
+        }
+
+        // Validate: if both project and task are specified, ensure task belongs to project
+        if let (Some(ref proj), Some(ref tsk)) = (&project_from_flag, &task_obj) {
+            if tsk.project.id != proj.id {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "Task \"{}\" belongs to project \"{}\", but you specified project \"{}\"",
+                    tsk.name, tsk.project.name, proj.name
+                ))));
+            }
+        }
+
+        // Determine final project: use task's project if only task provided, otherwise use flag/default
+        let project = if project_from_flag.is_none() {
+            task_obj.as_ref().map(|t| t.project.clone())
+        } else {
+            project_from_flag
+        }
+        .or(default_time_entry.project.clone());
 
         let tags = tags.unwrap_or(default_time_entry.tags.clone());
 
@@ -135,6 +183,7 @@ impl StartCommand {
                 tags,
                 billable,
                 workspace_id,
+                task: task_obj,
                 ..TimeEntry::default()
             };
             if interactive {

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -171,18 +171,14 @@ impl StartCommand {
         }
         .or(default_time_entry.project.clone());
 
-        // Validate: if both task and project are set, ensure task belongs to project
-        // If they don't match, drop the task (safer than erroring)
-        let task_obj = if let (Some(ref proj), Some(ref tsk)) = (&project, &task_obj) {
-            if tsk.project.id == proj.id {
-                Some(tsk.clone())
-            } else {
-                // Task doesn't belong to the final project, drop it
-                None
+        if let (Some(ref proj), Some(ref tsk)) = (&project, &task_obj) {
+            if tsk.project.id != proj.id {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "Task \"{}\" belongs to project \"{}\", but project \"{}\" was selected",
+                    tsk.name, tsk.project.name, proj.name
+                ))));
             }
-        } else {
-            task_obj
-        };
+        }
 
         let tags = tags.unwrap_or(default_time_entry.tags.clone());
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -160,6 +160,9 @@ impl StartCommand {
             }
         }
 
+        // Determine final task: use CLI flag if provided, otherwise fallback to config
+        let task_obj = task_obj.or(default_time_entry.task.clone());
+
         // Determine final project: use task's project if only task provided, otherwise use flag/default
         let project = if project_from_flag.is_none() {
             task_obj.as_ref().map(|t| t.project.clone())
@@ -167,6 +170,19 @@ impl StartCommand {
             project_from_flag
         }
         .or(default_time_entry.project.clone());
+
+        // Validate: if both task and project are set, ensure task belongs to project
+        // If they don't match, drop the task (safer than erroring)
+        let task_obj = if let (Some(ref proj), Some(ref tsk)) = (&project, &task_obj) {
+            if tsk.project.id == proj.id {
+                Some(tsk.clone())
+            } else {
+                // Task doesn't belong to the final project, drop it
+                None
+            }
+        } else {
+            task_obj
+        };
 
         let tags = tags.unwrap_or(default_time_entry.tags.clone());
 

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -536,11 +536,10 @@ impl TrackConfig {
         let project_id = project.clone().map(|p| p.id);
 
         let task = config.task.clone().and_then(|name| {
-            entities
-                .tasks
-                .clone()
-                .into_values()
-                .find(|t| t.name == name && t.project.id == project_id.unwrap())
+            entities.tasks.clone().into_values().find(|t| {
+                // Match task name and ensure it belongs to the configured project (if any)
+                t.name == name && project_id.is_none_or(|pid| t.project.id == pid)
+            })
         });
 
         let workspace_id = config.workspace.as_ref().map_or(

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,7 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 description,
                 project,
                 tags,
+                task,
             } => {
                 StartCommand::execute(
                     get_default_api_client()?,
@@ -128,6 +129,7 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                     tags,
                     billable,
                     interactive,
+                    task,
                 )
                 .await?
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -101,8 +101,13 @@ lazy_static! {
 }
 
 impl Project {
-    /// Gets the closest plain color to the TrueColor
-    pub fn name_in_closest_terminal_color(&self, red: u8, green: u8, blue: u8) -> ColoredString {
+    fn text_in_closest_terminal_color(
+        &self,
+        text: &str,
+        red: u8,
+        green: u8,
+        blue: u8,
+    ) -> ColoredString {
         let colors = vec![
             (0, 0, 0),       //Black
             (205, 0, 0),     //Red
@@ -140,23 +145,46 @@ impl Project {
             .1;
 
         match index {
-            0 => self.name.black(),
-            1 => self.name.red(),
-            2 => self.name.green(),
-            3 => self.name.yellow(),
-            4 => self.name.blue(),
-            5 => self.name.magenta(),
-            6 => self.name.cyan(),
-            7 => self.name.white(),
-            8 => self.name.bright_black(),
-            9 => self.name.bright_red(),
-            10 => self.name.bright_green(),
-            11 => self.name.bright_yellow(),
-            12 => self.name.bright_blue(),
-            13 => self.name.bright_magenta(),
-            14 => self.name.bright_cyan(),
-            15 => self.name.bright_white(),
-            _ => self.name.white().clear(),
+            0 => text.black(),
+            1 => text.red(),
+            2 => text.green(),
+            3 => text.yellow(),
+            4 => text.blue(),
+            5 => text.magenta(),
+            6 => text.cyan(),
+            7 => text.white(),
+            8 => text.bright_black(),
+            9 => text.bright_red(),
+            10 => text.bright_green(),
+            11 => text.bright_yellow(),
+            12 => text.bright_blue(),
+            13 => text.bright_magenta(),
+            14 => text.bright_cyan(),
+            15 => text.bright_white(),
+            _ => text.white().clear(),
+        }
+    }
+
+    /// Gets the closest plain color to the TrueColor
+    pub fn name_in_closest_terminal_color(&self, red: u8, green: u8, blue: u8) -> ColoredString {
+        self.text_in_closest_terminal_color(&self.name, red, green, blue)
+    }
+
+    pub fn name_like_project_color(&self, text: &str) -> ColoredString {
+        match Rgb::from_hex_str(self.color.as_str()) {
+            Ok(color) => {
+                let red = color.get_red().round() as u8;
+                let green = color.get_green().round() as u8;
+                let blue = color.get_blue().round() as u8;
+
+                if HAS_TRUECOLOR_SUPPORT.to_owned() {
+                    text.truecolor(red, green, blue).bold()
+                } else {
+                    self.text_in_closest_terminal_color(text, red, green, blue)
+                        .bold()
+                }
+            }
+            Err(_) => text.bold(),
         }
     }
 }
@@ -277,7 +305,7 @@ impl Default for TimeEntry {
 impl std::fmt::Display for TimeEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let summary = format!(
-            //{$/space} [{duration}]{running indicator/space} - {description/No Description}{@project/empty string} {#tags/empty string}
+            //{$/space} [{duration}]{running indicator/space} - {description/No Description}{@project/empty string}{(Task: ...)/empty string} {#tags/empty string}
             "{} [{}]{} –  {}{} {}",
             if self.billable {
                 "$".green().bold().to_string()
@@ -291,9 +319,21 @@ impl std::fmt::Display for TimeEntry {
             },
             if self.is_running() { "*" } else { " " },
             self.get_description().replace('\n', " "),
-            match self.project.clone() {
-                Some(p) => format!(" @{p}"),
-                None => "".to_string(),
+            match (self.project.clone(), self.task.clone()) {
+                (Some(p), Some(t)) => {
+                    format!(
+                        " @{}",
+                        p.name_like_project_color(&format!("{}: {}", p.name, t.name))
+                    )
+                }
+                (Some(p), None) => format!(" @{p}"),
+                (None, Some(t)) => {
+                    format!(
+                        " {}",
+                        t.project.name_like_project_color(&format!(": {}", t.name))
+                    )
+                }
+                (None, None) => "".to_string(),
             },
             if self.tags.is_empty() {
                 "".to_string()

--- a/src/models.rs
+++ b/src/models.rs
@@ -329,8 +329,9 @@ impl std::fmt::Display for TimeEntry {
                 (Some(p), None) => format!(" @{p}"),
                 (None, Some(t)) => {
                     format!(
-                        " {}",
-                        t.project.name_like_project_color(&format!(": {}", t.name))
+                        " @{}",
+                        t.project
+                            .name_like_project_color(&format!("{}: {}", t.project.name, t.name))
                     )
                 }
                 (None, None) => "".to_string(),


### PR DESCRIPTION
This adds `--task` support to `toggl start` and improves task visibility in the command output.

```terminal
# Project without task (previous behavior)
toggl start --project "My Project"

# Task only (project inferred from task)
toggl start --task "Development"

# Project and task
toggl start --project "My Project" --task "Development"
```

It now also shows task context in the started entry summary when a task is present, using Toggl-style formatting:

```terminal
$ [0:00:00]* –  Continue with work @My Project: Development
```

The `: task` segment is only shown when a task exists, and it is colorized to match the project label.

This also works when project and task are defined in config: `toggl start "Description"` will still pick up the configured `project` and `task` and display them in the output.

CC: @shantanuraj