### PR TITLE
feat: add edit, delete time entry and date filter for list

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -32,6 +32,16 @@ pub trait ApiClient {
 
     async fn create_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<i64>;
     async fn update_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<i64>;
+    async fn get_time_entries_filtered(
+        &self,
+        since: Option<String>,
+        until: Option<String>,
+    ) -> ResultWithDefaultError<Vec<TimeEntry>>;
+    async fn delete_time_entry(
+        &self,
+        workspace_id: i64,
+        time_entry_id: i64,
+    ) -> ResultWithDefaultError<()>;
 }
 
 pub struct V9ApiClient {
@@ -40,8 +50,22 @@ pub struct V9ApiClient {
 }
 
 impl V9ApiClient {
-    async fn get_time_entries(&self) -> ResultWithDefaultError<Vec<NetworkTimeEntry>> {
-        let url = format!("{}/me/time_entries", self.base_url);
+    async fn get_time_entries(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> ResultWithDefaultError<Vec<NetworkTimeEntry>> {
+        let mut url = format!("{}/me/time_entries", self.base_url);
+        let mut params: Vec<String> = Vec::new();
+        if let Some(since) = since {
+            params.push(format!("start_date={since}"));
+        }
+        if let Some(until) = until {
+            params.push(format!("end_date={until}"));
+        }
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
         self.get::<Vec<NetworkTimeEntry>>(url).await
     }
 
@@ -123,6 +147,19 @@ impl V9ApiClient {
             },
         }
     }
+
+    async fn delete(&self, url: String) -> ResultWithDefaultError<()> {
+        match self.http_client.delete(url).send().await {
+            Err(_) => Err(Box::new(ApiError::Network)),
+            Ok(response) => {
+                if response.status().is_success() {
+                    Ok(())
+                } else {
+                    Err(Box::new(ApiError::Deserialization))
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -148,6 +185,107 @@ impl ApiClient for V9ApiClient {
         return Ok(network_time_entry.id);
     }
 
+    async fn delete_time_entry(
+        &self,
+        workspace_id: i64,
+        time_entry_id: i64,
+    ) -> ResultWithDefaultError<()> {
+        let url = format!(
+            "{}/workspaces/{}/time_entries/{}",
+            self.base_url, workspace_id, time_entry_id
+        );
+        self.delete(url).await
+    }
+
+    async fn get_time_entries_filtered(
+        &self,
+        since: Option<String>,
+        until: Option<String>,
+    ) -> ResultWithDefaultError<Vec<TimeEntry>> {
+        // Fetch projects to resolve project names, then fetch filtered time entries.
+        let (network_entries, network_projects, network_tasks, network_clients) = tokio::join!(
+            self.get_time_entries(since.as_deref(), until.as_deref()),
+            self.get_projects(),
+            self.get_tasks(),
+            self.get_clients(),
+        );
+
+        let clients: HashMap<i64, crate::models::Client> = network_clients
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| {
+                (
+                    c.id,
+                    crate::models::Client {
+                        id: c.id,
+                        name: c.name,
+                        workspace_id: c.wid,
+                    },
+                )
+            })
+            .collect();
+
+        let projects: HashMap<i64, Project> = network_projects
+            .unwrap_or_default()
+            .into_iter()
+            .map(|p| {
+                (
+                    p.id,
+                    Project {
+                        id: p.id,
+                        name: p.name.clone(),
+                        workspace_id: p.workspace_id,
+                        client: clients.get(&p.client_id.unwrap_or(-1)).cloned(),
+                        is_private: p.is_private,
+                        active: p.active,
+                        at: p.at,
+                        created_at: p.created_at,
+                        color: p.color,
+                        billable: p.billable,
+                    },
+                )
+            })
+            .collect();
+
+        let tasks: HashMap<i64, Task> = network_tasks
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|t| {
+                projects.get(&t.project_id).map(|project| {
+                    (
+                        t.id,
+                        Task {
+                            id: t.id,
+                            name: t.name,
+                            project: project.clone(),
+                            workspace_id: t.workspace_id,
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        let entries = network_entries
+            .unwrap_or_default()
+            .into_iter()
+            .map(|te| TimeEntry {
+                id: te.id,
+                description: te.description,
+                start: te.start,
+                stop: te.stop,
+                duration: te.duration,
+                billable: te.billable,
+                workspace_id: te.workspace_id,
+                tags: te.tags.unwrap_or_default(),
+                project: projects.get(&te.project_id.unwrap_or(-1)).cloned(),
+                task: tasks.get(&te.task_id.unwrap_or(-1)).cloned(),
+                ..Default::default()
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
     async fn get_entities(&self) -> ResultWithDefaultError<Entities> {
         let (
             network_time_entries,
@@ -156,7 +294,7 @@ impl ApiClient for V9ApiClient {
             network_clients,
             network_workspaces,
         ) = tokio::join!(
-            self.get_time_entries(),
+            self.get_time_entries(None, None),
             self.get_projects(),
             self.get_tasks(),
             self.get_clients(),

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -27,9 +27,15 @@ pub enum Command {
         number: Option<usize>,
         #[structopt(short, long, help = "Output in JSON format")]
         json: bool,
-        #[structopt(long, help = "Filter entries starting on or after this date (YYYY-MM-DD)")]
+        #[structopt(
+            long,
+            help = "Filter entries starting on or after this date (YYYY-MM-DD)"
+        )]
         since: Option<String>,
-        #[structopt(long, help = "Filter entries starting on or before this date (YYYY-MM-DD)")]
+        #[structopt(
+            long,
+            help = "Filter entries starting on or before this date (YYYY-MM-DD)"
+        )]
         until: Option<String>,
         #[structopt(subcommand)]
         entity: Option<Entity>,
@@ -73,7 +79,9 @@ pub enum Command {
     },
     #[structopt(about = "Edit a time entry's description, project, or tags")]
     Edit {
-        #[structopt(help = "ID of the time entry to edit (omit to edit the currently running entry)")]
+        #[structopt(
+            help = "ID of the time entry to edit (omit to edit the currently running entry)"
+        )]
         id: Option<i64>,
         #[structopt(short, long, help = "New description")]
         description: Option<String>,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -27,6 +27,10 @@ pub enum Command {
         number: Option<usize>,
         #[structopt(short, long, help = "Output in JSON format")]
         json: bool,
+        #[structopt(long, help = "Filter entries starting on or after this date (YYYY-MM-DD)")]
+        since: Option<String>,
+        #[structopt(long, help = "Filter entries starting on or before this date (YYYY-MM-DD)")]
+        until: Option<String>,
         #[structopt(subcommand)]
         entity: Option<Entity>,
     },
@@ -66,6 +70,30 @@ pub enum Command {
     Continue {
         #[structopt(short, long)]
         interactive: bool,
+    },
+    #[structopt(about = "Edit a time entry's description, project, or tags")]
+    Edit {
+        #[structopt(help = "ID of the time entry to edit (omit to edit the currently running entry)")]
+        id: Option<i64>,
+        #[structopt(short, long, help = "New description")]
+        description: Option<String>,
+        #[structopt(
+            short,
+            long,
+            help = "New project name (use empty string \"\" to remove project)"
+        )]
+        project: Option<String>,
+        #[structopt(
+            short,
+            long,
+            help = "New space-separated list of tags (use empty string \"\" to clear tags)"
+        )]
+        tags: Option<Vec<String>>,
+    },
+    #[structopt(about = "Delete a time entry by ID")]
+    Delete {
+        #[structopt(help = "ID of the time entry to delete")]
+        id: i64,
     },
     #[structopt(about = "Manage auto-tracking configuration")]
     Config {

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,0 +1,28 @@
+use crate::api::client::ApiClient;
+use crate::models::ResultWithDefaultError;
+use colored::Colorize;
+
+pub struct DeleteCommand;
+
+impl DeleteCommand {
+    pub async fn execute(
+        api_client: impl ApiClient,
+        id: i64,
+    ) -> ResultWithDefaultError<()> {
+        let user = api_client.get_user().await?;
+        let workspace_id = user.default_workspace_id;
+
+        let entities = api_client.get_entities().await?;
+        let time_entry = entities.time_entries.iter().find(|te| te.id == id).cloned();
+
+        match time_entry {
+            None => println!("{}", format!("No time entry found with id {id}").yellow()),
+            Some(entry) => match api_client.delete_time_entry(workspace_id, id).await {
+                Err(error) => println!("{}\n{}", "Couldn't delete time entry".red(), error),
+                Ok(()) => println!("{}\n{}", "Time entry deleted successfully".green(), entry),
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -9,15 +9,12 @@ impl DeleteCommand {
         api_client: impl ApiClient,
         id: i64,
     ) -> ResultWithDefaultError<()> {
-        let user = api_client.get_user().await?;
-        let workspace_id = user.default_workspace_id;
-
         let entities = api_client.get_entities().await?;
         let time_entry = entities.time_entries.iter().find(|te| te.id == id).cloned();
 
         match time_entry {
             None => println!("{}", format!("No time entry found with id {id}").yellow()),
-            Some(entry) => match api_client.delete_time_entry(workspace_id, id).await {
+            Some(entry) => match api_client.delete_time_entry(entry.workspace_id, id).await {
                 Err(error) => println!("{}\n{}", "Couldn't delete time entry".red(), error),
                 Ok(()) => println!("{}\n{}", "Time entry deleted successfully".green(), entry),
             },

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -5,10 +5,7 @@ use colored::Colorize;
 pub struct DeleteCommand;
 
 impl DeleteCommand {
-    pub async fn execute(
-        api_client: impl ApiClient,
-        id: i64,
-    ) -> ResultWithDefaultError<()> {
+    pub async fn execute(api_client: impl ApiClient, id: i64) -> ResultWithDefaultError<()> {
         let entities = api_client.get_entities().await?;
         let time_entry = entities.time_entries.iter().find(|te| te.id == id).cloned();
 

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -1,0 +1,57 @@
+use crate::api::client::ApiClient;
+use crate::models::ResultWithDefaultError;
+use colored::Colorize;
+
+pub struct EditCommand;
+
+impl EditCommand {
+    pub async fn execute(
+        api_client: impl ApiClient,
+        id: Option<i64>,
+        description: Option<String>,
+        project_name: Option<String>,
+        tags: Option<Vec<String>>,
+    ) -> ResultWithDefaultError<()> {
+        let entities = api_client.get_entities().await?;
+
+        let time_entry = match id {
+            Some(id) => entities.time_entries.into_iter().find(|te| te.id == id),
+            None => entities.running_time_entry(),
+        };
+
+        match time_entry {
+            None => println!("{}", "No matching time entry found".yellow()),
+            Some(entry) => {
+                let project = match project_name.as_deref() {
+                    Some("") => None,
+                    Some(name) => entities
+                        .projects
+                        .into_values()
+                        .find(|p| p.name == name)
+                        .or(entry.project.clone()),
+                    None => entry.project.clone(),
+                };
+
+                let tags = match tags {
+                    Some(ref t) if t.len() == 1 && t[0].is_empty() => Vec::new(),
+                    Some(t) => t,
+                    None => entry.tags.clone(),
+                };
+
+                let updated = crate::models::TimeEntry {
+                    description: description.unwrap_or(entry.description.clone()),
+                    project,
+                    tags,
+                    ..entry
+                };
+
+                match api_client.update_time_entry(updated.clone()).await {
+                    Err(error) => println!("{}\n{}", "Couldn't update time entry".red(), error),
+                    Ok(_) => println!("{}\n{}", "Time entry updated successfully".green(), updated),
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -24,11 +24,15 @@ impl EditCommand {
             Some(entry) => {
                 let project = match project_name.as_deref() {
                     Some("") => None,
-                    Some(name) => entities
-                        .projects
-                        .into_values()
-                        .find(|p| p.name == name)
-                        .or(entry.project.clone()),
+                    Some(name) => match entities.projects.into_values().find(|p| p.name == name) {
+                        Some(project) => Some(project),
+                        None => {
+                            return Err(Box::new(std::io::Error::other(format!(
+                                "Project \"{}\" not found",
+                                name
+                            ))));
+                        }
+                    },
                     None => entry.project.clone(),
                 };
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -13,8 +13,51 @@ impl ListCommand {
         api_client: impl ApiClient,
         count: Option<usize>,
         json_flag: bool,
+        since: Option<String>,
+        until: Option<String>,
         entity: Option<Entity>,
     ) -> ResultWithDefaultError<()> {
+        let is_time_entry = matches!(
+            entity,
+            None | Some(Entity::TimeEntry { .. })
+        );
+        let has_date_filter = since.is_some() || until.is_some();
+
+        if is_time_entry && has_date_filter {
+            let stdout = io::stdout();
+            let mut handle = BufWriter::new(stdout);
+            let json = match &entity {
+                Some(Entity::TimeEntry { json }) => json_flag || *json,
+                _ => json_flag,
+            };
+            match api_client
+                .get_time_entries_filtered(since, until)
+                .await
+            {
+                Err(error) => println!(
+                    "{}\n{}",
+                    "Couldn't fetch time entries from API".red(),
+                    error
+                ),
+                Ok(entries) => {
+                    let entries = entries
+                        .iter()
+                        .take(count.unwrap_or(usize::MAX))
+                        .collect::<Vec<_>>();
+                    if json {
+                        let json_string = serde_json::to_string_pretty(&entries)
+                            .expect("failed to serialize time entries to JSON");
+                        writeln!(handle, "{json_string}").expect("failed to print");
+                    } else {
+                        entries.iter().for_each(|te| {
+                            writeln!(handle, "{te}").expect("failed to print")
+                        });
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         match api_client.get_entities().await {
             Err(error) => println!(
                 "{}\n{}",

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -17,10 +17,7 @@ impl ListCommand {
         until: Option<String>,
         entity: Option<Entity>,
     ) -> ResultWithDefaultError<()> {
-        let is_time_entry = matches!(
-            entity,
-            None | Some(Entity::TimeEntry { .. })
-        );
+        let is_time_entry = matches!(entity, None | Some(Entity::TimeEntry { .. }));
         let has_date_filter = since.is_some() || until.is_some();
 
         if is_time_entry && has_date_filter {
@@ -30,10 +27,7 @@ impl ListCommand {
                 Some(Entity::TimeEntry { json }) => json_flag || *json,
                 _ => json_flag,
             };
-            match api_client
-                .get_time_entries_filtered(since, until)
-                .await
-            {
+            match api_client.get_time_entries_filtered(since, until).await {
                 Err(error) => println!(
                     "{}\n{}",
                     "Couldn't fetch time entries from API".red(),
@@ -49,9 +43,9 @@ impl ListCommand {
                             .expect("failed to serialize time entries to JSON");
                         writeln!(handle, "{json_string}").expect("failed to print");
                     } else {
-                        entries.iter().for_each(|te| {
-                            writeln!(handle, "{te}").expect("failed to print")
-                        });
+                        entries
+                            .iter()
+                            .for_each(|te| writeln!(handle, "{te}").expect("failed to print"));
                     }
                 }
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod auth;
 pub mod cont;
+pub mod delete;
+pub mod edit;
 pub mod list;
 pub mod running;
 pub mod start;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use arguments::Command::Auth;
 use arguments::Command::Config;
 use arguments::Command::Continue;
 use arguments::Command::Current;
+use arguments::Command::Delete;
+use arguments::Command::Edit;
 use arguments::Command::List;
 use arguments::Command::Logout;
 use arguments::Command::Running;
@@ -24,6 +26,8 @@ use arguments::CommandLineArguments;
 use arguments::ConfigSubCommand;
 use commands::auth::AuthenticationCommand;
 use commands::cont::ContinueCommand;
+use commands::delete::DeleteCommand;
+use commands::edit::EditCommand;
 use commands::list::ListCommand;
 use commands::running::RunningTimeEntryCommand;
 use commands::start::StartCommand;
@@ -78,8 +82,13 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
             List {
                 number,
                 json,
+                since,
+                until,
                 entity,
-            } => ListCommand::execute(get_default_api_client()?, number, json, entity).await?,
+            } => {
+                ListCommand::execute(get_default_api_client()?, number, json, since, until, entity)
+                    .await?
+            }
 
             Current | Running => {
                 RunningTimeEntryCommand::execute(get_default_api_client()?).await?
@@ -103,6 +112,16 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 )
                 .await?
             }
+
+            Edit {
+                id,
+                description,
+                project,
+                tags,
+            } => EditCommand::execute(get_default_api_client()?, id, description, project, tags)
+                .await?,
+
+            Delete { id } => DeleteCommand::execute(get_default_api_client()?, id).await?,
 
             Auth { api_token } => {
                 let credentials = Credentials { api_token };

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,15 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 until,
                 entity,
             } => {
-                ListCommand::execute(get_default_api_client()?, number, json, since, until, entity)
-                    .await?
+                ListCommand::execute(
+                    get_default_api_client()?,
+                    number,
+                    json,
+                    since,
+                    until,
+                    entity,
+                )
+                .await?
             }
 
             Current | Running => {
@@ -118,8 +125,10 @@ async fn execute_subcommand(args: CommandLineArguments) -> ResultWithDefaultErro
                 description,
                 project,
                 tags,
-            } => EditCommand::execute(get_default_api_client()?, id, description, project, tags)
-                .await?,
+            } => {
+                EditCommand::execute(get_default_api_client()?, id, description, project, tags)
+                    .await?
+            }
 
             Delete { id } => DeleteCommand::execute(get_default_api_client()?, id).await?,
 


### PR DESCRIPTION
Adds three new commands for managing time entries.

## Edit a time entry

```bash
# Edit the currently running entry
toggl edit --description "New description"
toggl edit --project "My Project"
toggl edit --tags "dev meeting"

# Edit a specific entry by ID
toggl edit 4315772069 --description "Updated description"
toggl edit 4315772069 --project "Other Project" --tags "review"

# Remove project (pass empty string)
toggl edit 4315772069 --project ""

# Clear all tags (pass empty string)
toggl edit 4315772069 --tags ""
```

## Delete a time entry

```bash
toggl delete 4315772069
```

## Filter list by date range

```bash
# Entries from a specific day
toggl list --since 2026-03-01 --until 2026-03-01

# Entries from a date range
toggl list --since 2026-03-01 --until 2026-03-05

# Combine with --json and --number
toggl list --since 2026-03-01 --json
toggl list --since 2026-03-01 -n 5
```